### PR TITLE
Fix save behavior when dashboard data load fails

### DIFF
--- a/script.js
+++ b/script.js
@@ -111,14 +111,19 @@ const dashboardData = {
 
     async function loadDashboardData() {
         try {
-            return await $.getJSON('getter.php');
+            const result = await $.getJSON('getter.php');
+            if (result && !result.error) {
+                return result;
+            }
         } catch (e) {
-            return {};
+            // ignore
         }
+        return null;
     }
 
     let data = await loadDashboardData();
-    if (!data || !Object.keys(data).length) {
+    const loadSucceeded = !!(data && Object.keys(data).length);
+    if (!loadSucceeded) {
         const dataIn = dashboardDataIn;
         const dataOut = dashboardDataInOut;
         data = Object.assign({}, dataOut, { personalData: Object.assign({}, (dataOut.personalData || {}), (dataIn.personalData || {})) });
@@ -157,8 +162,12 @@ const dashboardData = {
     if (data.personalData && data.personalData.password) {
         data.personalData.passwordHash = await hashPassword(data.personalData.password);
         delete data.personalData.password;
+        if (loadSucceeded) {
+            saveData();
+        }
+    } else if (loadSucceeded) {
+        saveData();
     }
-    saveData();
 
     function parseDollar(str) {
         return parseFloat(String(str).replace(/[^0-9.-]+/g, '')) || 0;


### PR DESCRIPTION
## Summary
- detect failure when loading dashboard data
- only persist data after a successful load or user update

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685d63536f788326879c97968006d452