### PR TITLE
Fix password updates from user dashboard

### DIFF
--- a/change_password.php
+++ b/change_password.php
@@ -1,0 +1,47 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    echo json_encode(['success' => false, 'error' => 'Invalid JSON']);
+    exit;
+}
+
+$currentHash = $input['currentHash'] ?? '';
+$newHash = $input['newHash'] ?? '';
+$strength = $input['passwordStrength'] ?? null;
+$strengthBar = $input['passwordStrengthBar'] ?? null;
+
+try {
+    $dbHost = 'localhost';
+    $dbName = 'coin_db';
+    $dbUser = 'root';
+    $dbPass = '';
+    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $userId = (int)$_SESSION['user_id'];
+    $stmt = $pdo->prepare('SELECT passwordHash FROM personal_data WHERE id = ?');
+    $stmt->execute([$userId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row || $row['passwordHash'] !== $currentHash) {
+        echo json_encode(['success' => false, 'error' => 'Incorrect current password']);
+        exit;
+    }
+
+    $stmt = $pdo->prepare('UPDATE personal_data SET passwordHash = ?, passwordStrength = ?, passwordStrengthBar = ? WHERE id = ?');
+    $stmt->execute([$newHash, $strength, $strengthBar, $userId]);
+
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>

--- a/script.js
+++ b/script.js
@@ -457,27 +457,44 @@ $.each(data.personalData || {}, function (id, value) {
             alert('Les nouveaux mots de passe ne correspondent pas.');
             return;
         }
-        data.personalData.passwordHash = await hashPassword(newPw);
+        const newHash = await hashPassword(newPw);
         const score = computePasswordStrength(newPw);
         const label = strengthLabel(score);
         const cls = barClass(score);
 
-        $('#passwordStrength')
-			.text(label)
-			.removeClass('bg-success bg-warning bg-danger')
-			.addClass(cls);
-        $('#passwordStrengthBar')
-            .css('width', score + "%")
-            .attr('aria-valuenow', score)
-            .removeClass('bg-success bg-warning bg-danger')
-            .addClass(cls);
+        $.ajax({
+            url: 'change_password.php',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                currentHash: currentHash,
+                newHash: newHash,
+                passwordStrength: label,
+                passwordStrengthBar: score + '%'
+            })
+        }).done(function (resp) {
+            if (resp && resp.success) {
+                data.personalData.passwordHash = newHash;
+                data.personalData.passwordStrength = label;
+                data.personalData.passwordStrengthBar = score + '%';
 
-        data.personalData.passwordStrength = label;
-        data.personalData.passwordStrengthBar = score + '%';
+                $('#passwordStrength')
+                    .text(label)
+                    .removeClass('bg-success bg-warning bg-danger')
+                    .addClass(cls);
+                $('#passwordStrengthBar')
+                    .css('width', score + '%')
+                    .attr('aria-valuenow', score)
+                    .removeClass('bg-success bg-warning bg-danger')
+                    .addClass(cls);
 
-        saveData();
-        $('#changePasswordModal').modal('hide');
-        $('#changePasswordForm')[0].reset();
+                saveData();
+                $('#changePasswordModal').modal('hide');
+                $('#changePasswordForm')[0].reset();
+            } else {
+                alert((resp && resp.error) || 'Erreur lors de la mise \u00e0 jour du mot de passe');
+            }
+        });
     });
 
     $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #cryptoWithdrawForm, #paypalWithdrawForm, #bankAccountForm, #changePasswordForm, #changeProfilePicForm').on('submit', function (e) {


### PR DESCRIPTION
## Summary
- add `change_password.php` endpoint for password updates
- call new endpoint from JS when user saves new password

## Testing
- `php -l change_password.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d93dca9348326a436773059c19db2