### PR TITLE
Filter personal data before save

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,12 +70,27 @@ $(document).ready(async function () {
     }
 
     function saveData() {
+        const allowed = [
+            'balance','totalDepots','totalRetraits','nbTransactions','fullName',
+            'compteverifie','compteverifie01','niveauavance','passwordHash',
+            'passwordStrength','passwordStrengthBar','emailNotifications',
+            'smsNotifications','loginAlerts','transactionAlerts','twoFactorAuth',
+            'emailaddress','address','phone','dob','nationality','btcAddress',
+            'ethAddress','usdtAddress','widhrawbankname','widhrawusername',
+            'widhrawacountnumber','widhrawiben','widhrawswift'
+        ];
+        const pd = {};
+        allowed.forEach(f => {
+            if (Object.prototype.hasOwnProperty.call(data.personalData, f)) {
+                pd[f] = data.personalData[f];
+            }
+        });
         $.ajax({
             url: 'setter.php',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({
-                personalData: data.personalData,
+                personalData: pd,
                 transactions: data.transactions,
                 notifications: data.notifications,
                 deposits: data.deposits,


### PR DESCRIPTION
## Summary
- send only valid personal_data columns when storing updates

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_685e42022d68832690999658cb0143d6