### PR TITLE
Add wallet management API

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,6 +93,15 @@ $(document).ready(async function () {
         });
     }
 
+    function walletApi(action, payload) {
+        return $.ajax({
+            url: 'wallet_api.php',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(Object.assign({ action: action }, payload))
+        });
+    }
+
     function updateBalances() {
         const bal = formatDollar(parseDollar(data.personalData.balance));
         $('#soldeTotal').text(bal);
@@ -692,8 +701,8 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
     $(document).on('click', '.wallet-delete', function () {
         const id = $(this).data('id');
         if (confirm('Êtes-vous sûr de vouloir supprimer cette adresse ?')) {
+            walletApi('delete', { id });
             data.personalData.wallets = (data.personalData.wallets || []).filter(w => w.id !== id);
-            saveData();
             renderWalletTable();
         }
     });
@@ -705,7 +714,7 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
         const newAddr = prompt('Entrez la nouvelle adresse', wallet.address || '');
         if (newAddr !== null) {
             wallet.address = newAddr;
-            saveData();
+            walletApi('edit', { id, address: newAddr, label: wallet.label });
             renderWalletTable();
         }
     });
@@ -720,7 +729,7 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
             return;
         }
         const wallet = {
-            id: Date.now(),
+            id: String(Date.now()),
             currency,
             network,
             address,
@@ -729,7 +738,7 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
         data.personalData.wallets = data.personalData.wallets || [];
         data.personalData.wallets.push(wallet);
         saveForm('addWalletForm');
-        saveData();
+        walletApi('add', wallet).done(res => { if(res.id) wallet.id = res.id; });
         renderWalletTable();
         $('#addWalletModal').modal('hide');
         $('#walletCurrency').val('');

--- a/wallet_api.php
+++ b/wallet_api.php
@@ -1,0 +1,62 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+try {
+    $dbHost = 'localhost';
+    $dbName = 'coin_db';
+    $dbUser = 'root';
+    $dbPass = '';
+    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    if (!isset($_SESSION['user_id'])) {
+        http_response_code(401);
+        echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+        exit;
+    }
+    $userId = (int)$_SESSION['user_id'];
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!$input || !isset($input['action'])) {
+        throw new Exception('Invalid request');
+    }
+    $action = $input['action'];
+    switch ($action) {
+        case 'add':
+            $id = $input['id'] ?? uniqid();
+            $stmt = $pdo->prepare('INSERT INTO wallets (id, user_id, currency, network, address, label) VALUES (?,?,?,?,?,?)');
+            $stmt->execute([
+                $id,
+                $userId,
+                $input['currency'] ?? '',
+                $input['network'] ?? '',
+                $input['address'] ?? '',
+                $input['label'] ?? ''
+            ]);
+            echo json_encode(['success' => true, 'id' => $id]);
+            break;
+        case 'edit':
+            $stmt = $pdo->prepare('UPDATE wallets SET address = ?, label = ? WHERE id = ? AND user_id = ?');
+            $stmt->execute([
+                $input['address'] ?? '',
+                $input['label'] ?? '',
+                $input['id'] ?? '',
+                $userId
+            ]);
+            echo json_encode(['success' => true]);
+            break;
+        case 'delete':
+            $stmt = $pdo->prepare('DELETE FROM wallets WHERE id = ? AND user_id = ?');
+            $stmt->execute([
+                $input['id'] ?? '',
+                $userId
+            ]);
+            echo json_encode(['success' => true]);
+            break;
+        default:
+            throw new Exception('Unknown action');
+    }
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- create `wallet_api.php` with add, edit, and delete actions for wallets
- integrate API calls in `script.js` for managing wallets without re-saving all data

## Testing
- `php -l wallet_api.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e77b2a2b88326ab0e2ed442f966f3