### PR TITLE
Enhance wallet management

### DIFF
--- a/dashbord_user.php
+++ b/dashbord_user.php
@@ -1218,6 +1218,41 @@ if (!isset($_SESSION['user_id'])) {
 </div>
 </div>
 </div>
+<!-- Modal: Modifier Portefeuille -->
+<div class="modal fade" id="editWalletModal" tabindex="-1" aria-labelledby="editWalletModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="editWalletModalLabel">Modifier le portefeuille</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <form id="editWalletForm">
+                    <div class="mb-3">
+                        <label class="form-label" for="editWalletCurrency">Crypto-monnaie</label>
+                        <input class="form-control" id="editWalletCurrency" disabled type="text"/>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="editWalletNetwork">Réseau</label>
+                        <input class="form-control" id="editWalletNetwork" disabled type="text"/>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="editWalletAddress">Adresse du portefeuille</label>
+                        <input class="form-control" id="editWalletAddress" required type="text"/>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="editWalletLabel">Nom du portefeuille (optionnel)</label>
+                        <input class="form-control" id="editWalletLabel" type="text"/>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary" id="saveWalletBtn">Enregistrer</button>
+            </div>
+        </div>
+    </div>
+</div>
 <!-- Modal: Historique des connexions -->
 <div class="modal fade" id="loginHistoryModal" tabindex="-1" aria-labelledby="loginHistoryModalLabel" aria-hidden="true">
   <div class="modal-dialog">

--- a/script.js
+++ b/script.js
@@ -681,6 +681,8 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
     });
     updateCryptoDepositAddress();
 
+    let editingWalletId = null;
+
     function renderWalletTable() {
         const $tbody = $('#walletTableBody');
         $tbody.empty();
@@ -701,22 +703,39 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
     $(document).on('click', '.wallet-delete', function () {
         const id = $(this).data('id');
         if (confirm('Êtes-vous sûr de vouloir supprimer cette adresse ?')) {
-            walletApi('delete', { id });
-            data.personalData.wallets = (data.personalData.wallets || []).filter(w => w.id !== id);
-            renderWalletTable();
+            walletApi('delete', { id }).done(() => {
+                data.personalData.wallets = (data.personalData.wallets || []).filter(w => w.id !== id);
+                renderWalletTable();
+            });
         }
     });
 
     $(document).on('click', '.wallet-edit', function () {
-        const id = $(this).data('id');
-        const wallet = (data.personalData.wallets || []).find(w => w.id === id);
+        editingWalletId = $(this).data('id');
+        const wallet = (data.personalData.wallets || []).find(w => w.id === editingWalletId);
         if (!wallet) return;
-        const newAddr = prompt('Entrez la nouvelle adresse', wallet.address || '');
-        if (newAddr !== null) {
-            wallet.address = newAddr;
-            walletApi('edit', { id, address: newAddr, label: wallet.label });
-            renderWalletTable();
+        $('#editWalletCurrency').val(currencyNames[wallet.currency] || wallet.currency);
+        $('#editWalletNetwork').val(wallet.network);
+        $('#editWalletAddress').val(wallet.address || '');
+        $('#editWalletLabel').val(wallet.label || '');
+        $('#editWalletModal').modal('show');
+    });
+
+    $('#saveWalletBtn').on('click', function () {
+        const address = $('#editWalletAddress').val().trim();
+        const label = $('#editWalletLabel').val().trim();
+        if (!address) {
+            alert('Veuillez remplir tous les champs requis.');
+            return;
         }
+        const wallet = (data.personalData.wallets || []).find(w => w.id === editingWalletId);
+        if (!wallet) return;
+        wallet.address = address;
+        wallet.label = label;
+        walletApi('edit', { id: editingWalletId, address, label }).done(() => {
+            renderWalletTable();
+            $('#editWalletModal').modal('hide');
+        });
     });
 
     $('#addWalletBtn').on('click', function () {


### PR DESCRIPTION
## Summary
- add modal to edit crypto wallet addresses
- hook up wallet deletion to update the table after API call
- support editing wallets via modal instead of prompt

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7a4b3d3483269e5ca8e727d3b6bd