### PR TITLE
Add wallet edit modal

### DIFF
--- a/dashbord_user.php
+++ b/dashbord_user.php
@@ -1217,6 +1217,41 @@ if (!isset($_SESSION['user_id'])) {
 </div>
 </div>
 </div>
+<!-- Modal: Modifier portefeuille -->
+<div class="modal fade" id="editWalletModal" tabindex="-1" aria-labelledby="editWalletModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editWalletModalLabel">Modifier le portefeuille</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+      </div>
+      <div class="modal-body">
+        <form id="editWalletForm">
+          <div class="mb-3">
+            <label class="form-label" for="editWalletCurrency">Crypto-monnaie</label>
+            <input type="text" class="form-control" id="editWalletCurrency" disabled>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="editWalletNetwork">Réseau</label>
+            <input type="text" class="form-control" id="editWalletNetwork" disabled>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="editWalletAddress">Adresse du portefeuille</label>
+            <input type="text" class="form-control" id="editWalletAddress" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="editWalletLabel">Nom du portefeuille (optionnel)</label>
+            <input type="text" class="form-control" id="editWalletLabel">
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+        <button type="button" class="btn btn-primary" id="saveWalletEditBtn">Enregistrer</button>
+      </div>
+    </div>
+  </div>
+</div>
 </div>
 <!-- Modal: Historique des connexions -->
 <div class="modal fade" id="loginHistoryModal" tabindex="-1" aria-labelledby="loginHistoryModalLabel" aria-hidden="true">

--- a/script.js
+++ b/script.js
@@ -682,19 +682,15 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
     updateCryptoDepositAddress();
 
     let editingWalletId = null;
-    let walletEditMode = false; // false for add, true for edit
 
     $('#addWalletModal').on('show.bs.modal', function () {
-        if (!walletEditMode) {
-            $('#addWalletModalLabel').text('Ajouter un nouveau portefeuille');
-            $('#addWalletBtn').text('Ajouter');
-            $('#walletCurrency').prop('disabled', false);
-            $('#walletNetwork').prop('disabled', false);
-            $('#walletCurrency').val('');
-            populateNetworks();
-            $('#walletAddressNew').val('');
-            $('#walletLabel').val('');
-        }
+        $('#addWalletModalLabel').text('Ajouter un nouveau portefeuille');
+        $('#addWalletBtn').text('Ajouter');
+        $('#walletCurrency').prop('disabled', false).val('');
+        $('#walletNetwork').prop('disabled', false);
+        populateNetworks();
+        $('#walletAddressNew').val('');
+        $('#walletLabel').val('');
     });
 
     function renderWalletTable() {
@@ -732,18 +728,36 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
         editingWalletId = $(this).data('id');
         const wallet = (data.personalData.wallets || []).find(w => w.id === editingWalletId);
         if (!wallet) return;
-        walletEditMode = true;
-        $('#addWalletModalLabel').text('Modifier le portefeuille');
-        $('#addWalletBtn').text('Enregistrer');
-        $('#walletCurrency').val(wallet.currency).prop('disabled', true);
-        populateNetworks();
-        $('#walletNetwork').val(wallet.network).prop('disabled', true);
-        $('#walletAddressNew').val(wallet.address || '');
-        $('#walletLabel').val(wallet.label || '');
-        $('#addWalletModal').modal('show');
+        $('#editWalletCurrency').val(currencyNames[wallet.currency] || wallet.currency);
+        $('#editWalletNetwork').val(wallet.network);
+        $('#editWalletAddress').val(wallet.address || '');
+        $('#editWalletLabel').val(wallet.label || '');
+        $('#editWalletModal').modal('show');
     });
 
-    // Save wallet (add or edit)
+    $('#saveWalletEditBtn').on('click', function () {
+        const address = $('#editWalletAddress').val().trim();
+        const label = $('#editWalletLabel').val().trim();
+        if (!address) {
+            alert('Veuillez remplir l\'adresse du portefeuille.');
+            return;
+        }
+        const wallet = (data.personalData.wallets || []).find(w => w.id === editingWalletId);
+        if (!wallet) return;
+        wallet.address = address;
+        wallet.label = label;
+        walletApi('edit', { id: editingWalletId, address, label }).done(res => {
+            if (res && res.success) {
+                renderWalletTable();
+                $('#editWalletModal').modal('hide');
+                editingWalletId = null;
+            } else {
+                alert((res && res.error) || 'Erreur lors de la mise à jour');
+            }
+        });
+    });
+
+    // Save wallet (add only)
     $('#addWalletBtn').on('click', function () {
         const currency = $('#walletCurrency').val();
         const network = $('#walletNetwork').val();
@@ -754,43 +768,25 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
             return;
         }
 
-        if (walletEditMode) {
-            const wallet = (data.personalData.wallets || []).find(w => w.id === editingWalletId);
-            if (!wallet) return;
-            wallet.address = address;
-            wallet.label = label;
-            walletApi('edit', { id: editingWalletId, address, label }).done(res => {
-                if (res && res.success) {
-                    renderWalletTable();
-                } else {
-                    alert((res && res.error) || "Erreur lors de la mise à jour");
-                }
-            });
-        } else {
-            const wallet = {
-                id: String(Date.now()),
-                currency,
-                network,
-                address,
-                label
-            };
-            data.personalData.wallets = data.personalData.wallets || [];
-            data.personalData.wallets.push(wallet);
-            saveForm('addWalletForm');
-            walletApi('add', wallet).done(res => { if(res.id) wallet.id = res.id; });
-            renderWalletTable();
-        }
+        const wallet = {
+            id: String(Date.now()),
+            currency,
+            network,
+            address,
+            label
+        };
+        data.personalData.wallets = data.personalData.wallets || [];
+        data.personalData.wallets.push(wallet);
+        saveForm('addWalletForm');
+        walletApi('add', wallet).done(res => { if(res.id) wallet.id = res.id; });
+        renderWalletTable();
 
         $('#addWalletModal').modal('hide');
         $('#walletCurrency').prop('disabled', false).val('');
-        populateNetworks();
         $('#walletNetwork').prop('disabled', false);
+        populateNetworks();
         $('#walletAddressNew').val('');
         $('#walletLabel').val('');
-        $('#addWalletModalLabel').text('Ajouter un nouveau portefeuille');
-        $('#addWalletBtn').text('Ajouter');
-        walletEditMode = false;
-        editingWalletId = null;
     });
     // ======================== Gestion des historiques ========================
     function renderDepositHistory() {


### PR DESCRIPTION
## Summary
- create an `editWalletModal` to edit crypto addresses
- adjust JS to open the new modal when clicking the edit icon
- add handler to save wallet modifications using `wallet_api`
- simplify add wallet logic

## Testing
- `php -l dashbord_user.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e90d6d83c8326abe08c7fde0ae68a