### PR TITLE
Sync withdraw form with bank account updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -299,6 +299,15 @@ $(document).ready(async function () {
 
     syncBankAccountToWithdraw();
 
+    // When bank account information changes, immediately update withdraw form
+    // and persist the values.
+    $('#bankAccountForm input').on('input', function () {
+        data.formData['bankAccountForm'] = data.formData['bankAccountForm'] || {};
+        data.formData['bankAccountForm'][this.id] = $(this).val();
+        syncBankAccountToWithdraw(true);
+        saveData();
+    });
+
     renderWalletTable();
     // ======================== تعبئة البيانات الشخصية ========================
 $.each(data.personalData || {}, function (id, value) {


### PR DESCRIPTION
## Summary
- make bankWithdrawForm update instantly when bankAccountForm inputs change

## Testing
- `php -l getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea328756483268c7cc9aca9bd24d1