### PR TITLE
Insert bank account alert and success message

### DIFF
--- a/dashbord_user.php
+++ b/dashbord_user.php
@@ -1061,6 +1061,7 @@ if (!isset($_SESSION['user_id'])) {
 <div class="alert alert-info">
 <i class="fas fa-info-circle me-2"></i> Ces informations seront utilisées pour les retraits automatiques.
                       </div>
+<div id="bankAccountAlert"></div>
 <form id="bankAccountForm">
 <div class="mb-3">
 <label class="form-label" for="defaultBankName">Nom de la banque</label>

--- a/script.js
+++ b/script.js
@@ -567,6 +567,7 @@ $('#bankDepositForm, #cardDepositForm, #cryptoDepositForm, #bankWithdrawForm, #c
     saveForm(this.id);
     if (this.id === 'bankAccountForm') {
         syncBankAccountToWithdraw(true);
+        showBootstrapAlert('bankAccountAlert', 'Vos informations bancaires ont \xE9t\xE9 mises \xE0 jour.', 'success');
     }
 
         const today = new Date().toISOString().split('T')[0].replace(/-/g, '/');


### PR DESCRIPTION
## Summary
- show a placeholder for bank account alerts in dashboard
- display a success alert when bank account info is updated

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_685ea8f787bc8326b27070232b5942b0