### PR TITLE
Use shared DB configuration

### DIFF
--- a/change_password.php
+++ b/change_password.php
@@ -20,10 +20,7 @@ $strength = $input['passwordStrength'] ?? null;
 $strengthBar = $input['passwordStrengthBar'] ?? null;
 
 try {
-    $dbHost = 'localhost';
-    $dbName = 'coin_db';
-    $dbUser = 'root';
-    $dbPass = '';
+    require __DIR__ . '/config.php';
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/config.php
+++ b/config.php
@@ -1,0 +1,7 @@
+<?php
+// Database configuration
+$dbHost = 'localhost';
+$dbName = 'coin_db';
+$dbUser = 'root';
+$dbPass = '';
+?>

--- a/getter.php
+++ b/getter.php
@@ -2,11 +2,8 @@
 session_start();
 header('Content-Type: application/json');
 try {
-    // Connect to MySQL instead of the previous SQLite database
-    $dbHost = 'localhost';
-    $dbName = 'coin_db';
-    $dbUser = 'root';
-    $dbPass = '';
+    // Connect to MySQL
+    require __DIR__ . '/config.php';
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/login.php
+++ b/login.php
@@ -6,10 +6,7 @@ if (isset($_SESSION['user_id'])) {
 }
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $dbHost = 'localhost';
-    $dbName = 'coin_db';
-    $dbUser = 'root';
-    $dbPass = '';
+    require __DIR__ . '/config.php';
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/setter.php
+++ b/setter.php
@@ -2,11 +2,8 @@
 session_start();
 header('Content-Type: application/json');
 try {
-    // Connect to MySQL instead of the previous SQLite database
-    $dbHost = 'localhost';
-    $dbName = 'coin_db';
-    $dbUser = 'root';
-    $dbPass = '';
+    // Connect to MySQL
+    require __DIR__ . '/config.php';
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/wallet_api.php
+++ b/wallet_api.php
@@ -2,10 +2,7 @@
 session_start();
 header('Content-Type: application/json');
 try {
-    $dbHost = 'localhost';
-    $dbName = 'coin_db';
-    $dbUser = 'root';
-    $dbPass = '';
+    require __DIR__ . '/config.php';
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
## Summary
- centralize DB credentials in new `config.php`
- load config in login, getter, setter, change password and wallet API scripts

## Testing
- `php -l change_password.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eae26cd7c8326be09ef6cbd411fff