### PR TITLE
Switch to PHP password_hash

### DIFF
--- a/change_password.php
+++ b/change_password.php
@@ -14,8 +14,8 @@ if (!$input) {
     exit;
 }
 
-$currentHash = $input['currentHash'] ?? '';
-$newHash = $input['newHash'] ?? '';
+$currentPassword = $input['currentPassword'] ?? '';
+$newPassword = $input['newPassword'] ?? '';
 $strength = $input['passwordStrength'] ?? null;
 $strengthBar = $input['passwordStrengthBar'] ?? null;
 
@@ -32,11 +32,12 @@ try {
     $stmt = $pdo->prepare('SELECT passwordHash FROM personal_data WHERE id = ?');
     $stmt->execute([$userId]);
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
-    if (!$row || $row['passwordHash'] !== $currentHash) {
+    if (!$row || !password_verify($currentPassword, $row['passwordHash'])) {
         echo json_encode(['success' => false, 'error' => 'Incorrect current password']);
         exit;
     }
 
+    $newHash = password_hash($newPassword, PASSWORD_DEFAULT);
     $stmt = $pdo->prepare('UPDATE personal_data SET passwordHash = ?, passwordStrength = ?, passwordStrengthBar = ? WHERE id = ?');
     $stmt->execute([$newHash, $strength, $strengthBar, $userId]);
 

--- a/login.php
+++ b/login.php
@@ -15,11 +15,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $email = $_POST['email'] ?? '';
     $password = $_POST['password'] ?? '';
-    $hash = hash('sha256', $password);
     $stmt = $pdo->prepare('SELECT id, passwordHash FROM personal_data WHERE emailaddress = ?');
     $stmt->execute([$email]);
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($user && $user['passwordHash'] === $hash) {
+    if ($user && password_verify($password, $user['passwordHash'])) {
         $_SESSION['user_id'] = $user['id'];
         header('Location: dashbord_user.php');
         exit;

--- a/script.js
+++ b/script.js
@@ -48,13 +48,7 @@ $(document).ready(async function () {
             }
         });
     }
-    if (data.personalData && data.personalData.password) {
-        data.personalData.passwordHash = await hashPassword(data.personalData.password);
-        delete data.personalData.password;
-        if (loadSucceeded) {
-            saveData();
-        }
-    } else if (loadSucceeded) {
+    if (loadSucceeded) {
         saveData();
     }
 
@@ -491,11 +485,6 @@ $.each(data.personalData || {}, function (id, value) {
         return Math.min(score, 100);
     }
 
-    async function hashPassword(pwd) {
-        const enc = new TextEncoder().encode(pwd);
-        const buffer = await crypto.subtle.digest('SHA-256', enc);
-        return Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('');
-    }
 
     function strengthLabel(score) {
         if (score >= 90) return 'Fort';
@@ -513,16 +502,10 @@ $.each(data.personalData || {}, function (id, value) {
         const current = $('#currentPassword').val();
         const newPw = $('#newPassword').val();
         const confirm = $('#confirmPassword').val();
-        const currentHash = await hashPassword(current);
-        if (currentHash !== data.personalData.passwordHash) {
-            alert('Mot de passe actuel incorrect');
-            return;
-        }
         if (newPw !== confirm) {
             alert('Les nouveaux mots de passe ne correspondent pas.');
             return;
         }
-        const newHash = await hashPassword(newPw);
         const score = computePasswordStrength(newPw);
         const label = strengthLabel(score);
         const cls = barClass(score);
@@ -532,14 +515,13 @@ $.each(data.personalData || {}, function (id, value) {
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({
-                currentHash: currentHash,
-                newHash: newHash,
+                currentPassword: current,
+                newPassword: newPw,
                 passwordStrength: label,
                 passwordStrengthBar: score + '%'
             })
         }).done(function (resp) {
             if (resp && resp.success) {
-                data.personalData.passwordHash = newHash;
                 data.personalData.passwordStrength = label;
                 data.personalData.passwordStrengthBar = score + '%';
 

--- a/seed_data.mysql.sql
+++ b/seed_data.mysql.sql
@@ -1,7 +1,7 @@
 INSERT INTO personal_data (
     balance, totalDepots, totalRetraits, nbTransactions, fullName, compteverifie, compteverifie01, niveauavance, passwordHash, passwordStrength, passwordStrengthBar, emailNotifications, smsNotifications, loginAlerts, transactionAlerts, twoFactorAuth, emailaddress, address, phone, dob, nationality, btcAddress, ethAddress, usdtAddress, widhrawbankname, widhrawusername, widhrawacountnumber, widhrawiben, widhrawswift
 ) VALUES (
-    '5000 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '6ce0330487c92a564b80836c30f81d5b33da46b4e0acaafa94c2211e38f1e01a', 'Fort', '90%', '1', '1', '1', '1', '0', 'Mider22@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Banque Nationale', 'Société de services financiers', '1234567890', 'SA1234567890123456789012', 'BNPARABIC'
+    '5000 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '$2b$10$xOMK7an7pZTpM8GKYISa1On.tsvzPqt9OiE8vqgZh7FgsL9HGNKMG', 'Fort', '90%', '1', '1', '1', '1', '0', 'Mider22@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Banque Nationale', 'Société de services financiers', '1234567890', 'SA1234567890123456789012', 'BNPARABIC'
 );
 
 INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES


### PR DESCRIPTION
## Summary
- use `password_verify()` when authenticating
- generate new password hashes with `password_hash()`
- adjust JS to send plain text passwords
- update seed data with bcrypt hashed password

## Testing
- `php -l login.php` *(fails: command not found)*
- `php -l change_password.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eae5ab82c832695d32ed9918841a7