### PR TITLE
Switch amount columns to numeric types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Migration Guide
+
+The schema previously stored monetary values as text. This update converts those fields to numeric types.
+
+## Database Changes
+Run the following SQL statements on your production database:
+
+```
+ALTER TABLE personal_data
+  MODIFY balance DECIMAL(18,2),
+  MODIFY totalDepots DECIMAL(18,2),
+  MODIFY totalRetraits DECIMAL(18,2),
+  MODIFY nbTransactions INT;
+
+ALTER TABLE transactions MODIFY amount DECIMAL(18,2);
+ALTER TABLE deposits MODIFY amount DECIMAL(18,2);
+ALTER TABLE retraits MODIFY amount DECIMAL(18,2);
+ALTER TABLE trading_history
+  MODIFY montant DECIMAL(18,2),
+  MODIFY prix DECIMAL(18,2),
+  MODIFY profitPerte DECIMAL(18,2);
+```
+
+## Cleaning Existing Data
+If your tables contain values with currency symbols (e.g. `$100` or `1,000 $`),
+you need to strip those characters before running the `ALTER TABLE` commands.
+The following examples show how to sanitize a column:
+
+```
+UPDATE transactions SET amount = REPLACE(REPLACE(amount, '$', ''), ',', '') WHERE amount LIKE '%$%';
+UPDATE personal_data SET balance = REPLACE(REPLACE(balance, '$', ''), ',', '');
+```
+Adjust these queries for each column that contains formatted amounts.
+
+After cleaning the data and applying the schema changes, the updated PHP code
+will correctly bind numeric values when inserting rows.

--- a/create_tables.mysql.sql
+++ b/create_tables.mysql.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS personal_data (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    balance TEXT,
-    totalDepots TEXT,
-    totalRetraits TEXT,
-    nbTransactions TEXT,
+    balance DECIMAL(18,2),
+    totalDepots DECIMAL(18,2),
+    totalRetraits DECIMAL(18,2),
+    nbTransactions INT,
     fullName TEXT,
     compteverifie TEXT,
     compteverifie01 TEXT,
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     user_id INT NOT NULL,
     operationNumber TEXT,
     type TEXT,
-    amount TEXT,
+    amount DECIMAL(18,2),
     date TEXT,
     status TEXT,
     statusClass TEXT
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS deposits (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
     date TEXT,
-    amount TEXT,
+    amount DECIMAL(18,2),
     method TEXT,
     status TEXT,
     statusClass TEXT
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS retraits (
     id INT AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
     date TEXT,
-    amount TEXT,
+    amount DECIMAL(18,2),
     method TEXT,
     status TEXT,
     statusClass TEXT
@@ -79,11 +79,11 @@ CREATE TABLE IF NOT EXISTS trading_history (
     paire_devises TEXT,
     type TEXT,
     statutTypeClass TEXT,
-    montant TEXT,
-    prix TEXT,
+    montant DECIMAL(18,2),
+    prix DECIMAL(18,2),
     statut TEXT,
     statutClass TEXT,
-    profitPerte TEXT,
+    profitPerte DECIMAL(18,2),
     profitClass TEXT
 );
 

--- a/seed_data.mysql.sql
+++ b/seed_data.mysql.sql
@@ -1,14 +1,14 @@
 INSERT INTO personal_data (
     balance, totalDepots, totalRetraits, nbTransactions, fullName, compteverifie, compteverifie01, niveauavance, passwordHash, passwordStrength, passwordStrengthBar, emailNotifications, smsNotifications, loginAlerts, transactionAlerts, twoFactorAuth, emailaddress, address, phone, dob, nationality, btcAddress, ethAddress, usdtAddress, widhrawbankname, widhrawusername, widhrawacountnumber, widhrawiben, widhrawswift
 ) VALUES (
-    '5000 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '6ce0330487c92a564b80836c30f81d5b33da46b4e0acaafa94c2211e38f1e01a', 'Fort', '90%', '1', '1', '1', '1', '0', 'Mider22@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Banque Nationale', 'Société de services financiers', '1234567890', 'SA1234567890123456789012', 'BNPARABIC'
+    5000, 1200, 800, 10, 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '6ce0330487c92a564b80836c30f81d5b33da46b4e0acaafa94c2211e38f1e01a', 'Fort', '90%', '1', '1', '1', '1', '0', 'Mider22@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Banque Nationale', 'Société de services financiers', '1234567890', 'SA1234567890123456789012', 'BNPARABIC'
 );
 
 INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES
-(1,'#12345','Dépôt','$100','06/01/2025','complet','bg-success'),
-(1,'#12344','Retrait','$200','05/28/2025','complet','bg-success'),
-(1,'#12343','Dépôt','$300','05/25/2025','complet','bg-success'),
-(1,'#12342','Retrait','$150','05/20/2025','En cours','bg-warning');
+(1,'#12345','Dépôt',100,'06/01/2025','complet','bg-success'),
+(1,'#12344','Retrait',200,'05/28/2025','complet','bg-success'),
+(1,'#12343','Dépôt',300,'05/25/2025','complet','bg-success'),
+(1,'#12342','Retrait',150,'05/20/2025','En cours','bg-warning');
 
 INSERT INTO notifications (user_id, type, title, message, time, alertClass) VALUES
 (1,'info','Mise à jour du système','Le système sera mis à jour vendredi prochain.','Il y a 2 heures','alert-info'),
@@ -16,19 +16,19 @@ INSERT INTO notifications (user_id, type, title, message, time, alertClass) VALU
 (1,'warning','Vérification KYC','Merci de vérifier votre identité.','Il y a 3 jours','alert-warning');
 
 INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES
-(1,'2025/06/01','$500','Carte','En cours','bg-warning'),
-(1,'2025/05/15','$300','Banque','complet','bg-success'),
-(1,'2025/05/02','$400','Bitcoin','complet','bg-success');
+(1,'2025/06/01',500,'Carte','En cours','bg-warning'),
+(1,'2025/05/15',300,'Banque','complet','bg-success'),
+(1,'2025/05/02',400,'Bitcoin','complet','bg-success');
 
 INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES
-(1,'2025/05/28','$200','Banque','complet','bg-success'),
-(1,'2025/05/20','$150','Bitcoin','En cours','bg-warning'),
-(1,'2025/05/10','$300','Paypal','complet','bg-success');
+(1,'2025/05/28',200,'Banque','complet','bg-success'),
+(1,'2025/05/20',150,'Bitcoin','En cours','bg-warning'),
+(1,'2025/05/10',300,'Paypal','complet','bg-success');
 
 INSERT INTO trading_history (user_id, temps, paire_devises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES
-(1,'2025/06/09 14:30','BTC/USD','Acheter','bg-success','$1,000','$500','complet','bg-success','+$175.50','text-success'),
-(1,'2025/06/09 13:15','ETH/USD','Vendre','bg-success','$500','$2,850','complet','bg-success','-$25.00','text-danger'),
-(1,'2025/06/09 12:00','ADA/USD','Acheter','bg-danger','$300','$0.45','En cours','bg-warning','-','');
+(1,'2025/06/09 14:30','BTC/USD','Acheter','bg-success',1000,500,'complet','bg-success',175.50,'text-success'),
+(1,'2025/06/09 13:15','ETH/USD','Vendre','bg-success',500,2850,'complet','bg-success',-25.00,'text-danger'),
+(1,'2025/06/09 12:00','ADA/USD','Acheter','bg-danger',300,0.45,'En cours','bg-warning',0,'');
 
 INSERT INTO login_history (user_id, date, ip, device) VALUES
 (1,'2025/06/09 15:00','192.168.0.1','Chrome - Windows'),

--- a/setter.php
+++ b/setter.php
@@ -8,6 +8,11 @@ try {
     $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+    function clean_decimal($v) {
+        if ($v === null || $v === '') return null;
+        return preg_replace('/[^0-9.\-]/', '', $v);
+    }
+
     $input = json_decode(file_get_contents('php://input'), true);
     if (!$input) {
         throw new Exception('Invalid JSON');
@@ -29,23 +34,46 @@ try {
         $place = '?,:' . implode(',:', $fields);
         $stmt = $pdo->prepare("INSERT INTO personal_data ($cols) VALUES ($place)");
         $stmt->bindValue(1, $userId, PDO::PARAM_INT);
+        $numericMap = ['balance'=>'decimal','totalDepots'=>'decimal','totalRetraits'=>'decimal','nbTransactions'=>'int'];
         foreach ($input['personalData'] as $k => $v) {
-            $stmt->bindValue(':' . $k, $v);
+            if (isset($numericMap[$k])) {
+                if ($numericMap[$k] === 'int') {
+                    $stmt->bindValue(':' . $k, (int)preg_replace('/[^0-9-]/', '', $v), PDO::PARAM_INT);
+                } else {
+                    $stmt->bindValue(':' . $k, clean_decimal($v));
+                }
+            } else {
+                $stmt->bindValue(':' . $k, $v);
+            }
         }
         $stmt->execute();
     }
 
-    function updateTable($pdo, $table, $fields, $rows, $userId) {
+function updateTable($pdo, $table, $fields, $rows, $userId) {
         if ($rows === null) return;
         $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$userId]);
         if (!is_array($rows)) return;
         $cols = 'user_id,' . implode(',', $fields);
         $placeholders = implode(',', array_fill(0, count($fields) + 1, '?'));
         $stmt = $pdo->prepare("INSERT INTO $table ($cols) VALUES ($placeholders)");
+        $decimalMap = [
+            'transactions'=>['amount'],
+            'deposits'=>['amount'],
+            'retraits'=>['amount'],
+            'trading_history'=>['montant','prix','profitPerte']
+        ];
         foreach ($rows as $row) {
-            $vals = [$userId];
-            foreach ($fields as $f) { $vals[] = $row[$f] ?? null; }
-            $stmt->execute($vals);
+            $idx = 1;
+            $stmt->bindValue($idx++, $userId, PDO::PARAM_INT);
+            foreach ($fields as $f) {
+                $val = $row[$f] ?? null;
+                if (isset($decimalMap[$table]) && in_array($f, $decimalMap[$table], true)) {
+                    $stmt->bindValue($idx++, clean_decimal($val));
+                } else {
+                    $stmt->bindValue($idx++, $val);
+                }
+            }
+            $stmt->execute();
         }
     }
 


### PR DESCRIPTION
## Summary
- store money amounts as numeric values in MySQL
- adjust seed data to drop currency symbols
- clean numbers before binding in `setter.php`
- document migration steps

## Testing
- `php -l setter.php` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685eaede89e8832693335c4c343e3064