### PR TITLE
Refactor PDO setup into helper

### DIFF
--- a/change_password.php
+++ b/change_password.php
@@ -20,10 +20,8 @@ $strength = $input['passwordStrength'] ?? null;
 $strengthBar = $input['passwordStrengthBar'] ?? null;
 
 try {
-    require __DIR__ . '/config.php';
-    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
-    $pdo = new PDO($dsn, $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    require_once __DIR__ . '/database.php';
+    $pdo = db_connect();
 
     $userId = (int)$_SESSION['user_id'];
     $stmt = $pdo->prepare('SELECT passwordHash FROM personal_data WHERE id = ?');

--- a/database.php
+++ b/database.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+/**
+ * Create and return a PDO connection using the configuration values.
+ *
+ * @return PDO
+ */
+function db_connect(): PDO {
+    $dsn = "mysql:host={$GLOBALS['dbHost']};dbname={$GLOBALS['dbName']};charset=utf8mb4";
+    $pdo = new PDO($dsn, $GLOBALS['dbUser'], $GLOBALS['dbPass']);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}

--- a/getter.php
+++ b/getter.php
@@ -3,10 +3,8 @@ session_start();
 header('Content-Type: application/json');
 try {
     // Connect to MySQL
-    require __DIR__ . '/config.php';
-    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
-    $pdo = new PDO($dsn, $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    require_once __DIR__ . '/database.php';
+    $pdo = db_connect();
 
     if (!isset($_SESSION['user_id'])) {
         http_response_code(401);

--- a/login.php
+++ b/login.php
@@ -6,10 +6,8 @@ if (isset($_SESSION['user_id'])) {
 }
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    require __DIR__ . '/config.php';
-    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
-    $pdo = new PDO($dsn, $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    require_once __DIR__ . '/database.php';
+    $pdo = db_connect();
     $email = $_POST['email'] ?? '';
     $password = $_POST['password'] ?? '';
     $stmt = $pdo->prepare('SELECT id, passwordHash FROM personal_data WHERE emailaddress = ?');

--- a/setter.php
+++ b/setter.php
@@ -3,10 +3,8 @@ session_start();
 header('Content-Type: application/json');
 try {
     // Connect to MySQL
-    require __DIR__ . '/config.php';
-    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
-    $pdo = new PDO($dsn, $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    require_once __DIR__ . '/database.php';
+    $pdo = db_connect();
 
     function clean_decimal($v) {
         if ($v === null || $v === '') return null;

--- a/wallet_api.php
+++ b/wallet_api.php
@@ -2,10 +2,8 @@
 session_start();
 header('Content-Type: application/json');
 try {
-    require __DIR__ . '/config.php';
-    $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
-    $pdo = new PDO($dsn, $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    require_once __DIR__ . '/database.php';
+    $pdo = db_connect();
 
     if (!isset($_SESSION['user_id'])) {
         http_response_code(401);


### PR DESCRIPTION
## Summary
- implement `db_connect` helper in `database.php`
- reuse helper across API endpoints and login

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685eb31cf388832685a24957d44e8479