### PR TITLE
Add backend API scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Coin Dashboard
+
+This project uses small PHP helpers (`getter.php` and `setter.php`) to read and update user data stored in an SQLite database. The schema is defined in `createtable.sql` and example data is provided in `insertdata.sql`.
+
+## Database setup
+
+1. Make sure the PHP SQLite PDO extension is installed.
+2. Create `database.sqlite` in the project root:
+   ```sh
+   sqlite3 database.sqlite < createtable.sql
+   sqlite3 database.sqlite < insertdata.sql
+   ```
+3. The PHP scripts assume the database is located at `database.sqlite`. Update the path inside `getter.php` and `setter.php` if needed.
+
+The dashboard pages (`dashbord_user.html` and `script.js`) request data from `getter.php` and send updates to `setter.php`.

--- a/getter.php
+++ b/getter.php
@@ -1,0 +1,39 @@
+<?php
+$dbPath = __DIR__ . '/database.sqlite';
+$dsn = 'sqlite:' . $dbPath;
+$pdo = new PDO($dsn);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
+
+function fetchAll($pdo, $sql, $params = []) {
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
+$personal = $personal ? $personal[0] : [];
+
+$data = [
+    'personalData' => $personal,
+    'wallets' => fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]),
+    'transactions' => fetchAll($pdo, 'SELECT operationNumber,type,amount,date,status,statusClass FROM transactions WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'notifications' => fetchAll($pdo, 'SELECT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'deposits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'retraits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'tradingHistory' => fetchAll($pdo, 'SELECT temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass FROM tradingHistory WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    // placeholders for front-end
+    'formData' => new stdClass(),
+    'defaultKYCStatus' => [
+        'enregistrementducomptestat' => ['status' => '1', 'date' => date('Y-m-d')],
+        'confirmationdeladresseemailstat' => ['status' => '1', 'date' => date('Y-m-d')],
+        'telechargerlesdocumentsdidentitestat' => ['status' => '0', 'date' => null],
+        'verificationdeladressestat' => ['status' => '0', 'date' => null],
+        'revisionfinalestat' => ['status' => '2', 'date' => null],
+    ],
+];
+
+header('Content-Type: application/json');
+echo json_encode($data);

--- a/setter.php
+++ b/setter.php
@@ -1,0 +1,81 @@
+<?php
+$dbPath = __DIR__ . '/database.sqlite';
+$pdo = new PDO('sqlite:' . $dbPath);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
+    exit;
+}
+
+$userId = $data['personalData']['user_id'] ?? $data['user_id'] ?? ($_POST['user_id'] ?? 1);
+
+try {
+    $pdo->beginTransaction();
+
+    if (isset($data['personalData'])) {
+        $personal = $data['personalData'];
+        $personal['user_id'] = $userId;
+        $wallets = $personal['wallets'] ?? ($data['wallets'] ?? []);
+        unset($personal['wallets']);
+
+        $cols = array_keys($personal);
+        $place = implode(',', array_fill(0, count($cols), '?'));
+        $sql = 'REPLACE INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($personal));
+    } else {
+        $wallets = $data['wallets'] ?? [];
+    }
+
+    $pdo->prepare('DELETE FROM wallets WHERE user_id = ?')->execute([$userId]);
+    if ($wallets) {
+        $stmt = $pdo->prepare('INSERT INTO wallets (id,user_id,currency,network,address,label) VALUES (?,?,?,?,?,?)');
+        foreach ($wallets as $w) {
+            $stmt->execute([
+                $w['id'] ?? null,
+                $userId,
+                $w['currency'] ?? '',
+                $w['network'] ?? '',
+                $w['address'] ?? '',
+                $w['label'] ?? ''
+            ]);
+        }
+    }
+
+    $tables = [
+        'transactions' => ['operationNumber','type','amount','date','status','statusClass'],
+        'notifications' => ['type','title','message','time','alertClass'],
+        'deposits' => ['date','amount','method','status','statusClass'],
+        'retraits' => ['date','amount','method','status','statusClass'],
+        'tradingHistory' => ['temps','paireDevises','type','statutTypeClass','montant','prix','statut','statutClass','profitPerte','profitClass'],
+        'loginHistory' => ['date','ip','device'],
+    ];
+
+    foreach ($tables as $table => $cols) {
+        $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$userId]);
+        if (isset($data[$table]) && is_array($data[$table])) {
+            $place = '(' . implode(',', array_fill(0, count($cols)+1, '?')) . ')';
+            $sql = "INSERT INTO $table (user_id," . implode(',', $cols) . ") VALUES $place";
+            $stmt = $pdo->prepare($sql);
+            foreach ($data[$table] as $row) {
+                $values = [$userId];
+                foreach ($cols as $c) {
+                    $values[] = $row[$c] ?? null;
+                }
+                $stmt->execute($values);
+            }
+        }
+    }
+
+    $pdo->commit();
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok']);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- add PHP `getter.php` for exposing dashboard data as JSON
- add PHP `setter.php` to update all tables in a single transaction
- document SQLite setup in `README.md`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edc62228c8326a09e119542598d2c