### PR TITLE
Add bank info columns and withdraw details

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ This project uses small PHP helpers (`getter.php` and `setter.php`) to read and 
 3. The PHP scripts connect to `coin_db` on `localhost` using the `root` user with an empty password. Update the connection settings in `getter.php` and `setter.php` if your environment differs.
 
 The dashboard pages (`dashbord_user.html` and `script.js`) request data from `getter.php` and send updates to `setter.php`.
+
+The `personal_data` table now includes columns for storing default bank details:
+`userBankName`, `userAccountName`, `userAccountNumber`, `userIban` and
+`userSwiftCode`. A helper table `bank_withdrawl_info` provides the bank
+information shown on the deposit screen.
+

--- a/createtable.sql
+++ b/createtable.sql
@@ -24,7 +24,12 @@ CREATE TABLE personal_data (
     nationality TEXT,
     btcAddress TEXT,
     ethAddress TEXT,
-    usdtAddress TEXT
+    usdtAddress TEXT,
+    userBankName TEXT,
+    userAccountName TEXT,
+    userAccountNumber TEXT,
+    userIban TEXT,
+    userSwiftCode TEXT
 );
 
 
@@ -43,3 +48,10 @@ CREATE TABLE deposits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, d
 CREATE TABLE retraits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, amount TEXT, method TEXT, status TEXT, statusClass TEXT);
 CREATE TABLE tradingHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, temps TEXT, paireDevises TEXT, type TEXT, statutTypeClass TEXT, montant TEXT, prix TEXT, statut TEXT, statutClass TEXT, profitPerte TEXT, profitClass TEXT);
 CREATE TABLE loginHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, ip TEXT, device TEXT);
+CREATE TABLE bank_withdrawl_info (
+    widhrawBankName TEXT,
+    widhrawAccountName TEXT,
+    widhrawAccountNumber TEXT,
+    widhrawIban TEXT,
+    widhrawSwiftCode TEXT
+);

--- a/getter.php
+++ b/getter.php
@@ -13,6 +13,8 @@ function fetchAll($pdo, $sql, $params = []) {
 
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
+$bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info LIMIT 1');
+$bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 
 $data = [
     'personalData' => $personal,
@@ -23,6 +25,7 @@ $data = [
     'retraits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY id DESC', [$userId]),
     'tradingHistory' => fetchAll($pdo, 'SELECT temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass FROM tradingHistory WHERE user_id = ? ORDER BY id DESC', [$userId]),
     'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'bankWithdrawInfo' => $bankWithdraw,
     // placeholders for front-end
     'formData' => new stdClass(),
     'defaultKYCStatus' => [

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -1,4 +1,4 @@
-INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '6ce0330487c92a564b80836c30f81d5b33da46b4e0acaafa94c2211e38f1e01a', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...');
+INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', '6ce0330487c92a564b80836c30f81d5b33da46b4e0acaafa94c2211e38f1e01a', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123');
 
 INSERT INTO wallets VALUES (
     1751038645430, 1, 'btc', 'Bitcoin',
@@ -32,3 +32,4 @@ INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/08 18:2
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/07 09:10', '192.168.0.3', 'Safari - iOS');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/06 23:45', '192.168.0.4', 'Edge - Windows');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/05 08:30', '192.168.0.5', 'Chrome - macOS');
+INSERT INTO bank_withdrawl_info VALUES ('My Bank', 'Company Ltd', '987654321', 'IBAN987654', 'SWIFT987');

--- a/script.js
+++ b/script.js
@@ -223,6 +223,13 @@ function initializeUI() {
 
     renderWalletTable();
 
+    const bw = dashboardData.bankWithdrawInfo || {};
+    $('#widhrawbankname').text(bw.widhrawBankName || '---');
+    $('#widhrawusername').text(bw.widhrawAccountName || '---');
+    $('#widhrawacountnumber').text(bw.widhrawAccountNumber || '---');
+    $('#widhrawiben').text(bw.widhrawIban || '---');
+    $('#widhrawswift').text(bw.widhrawSwiftCode || '---');
+
     $.each(dashboardData.personalData || {}, function (id, value) {
         if (id === "passwordStrengthBar") {
             const $bar = $('#' + id);
@@ -258,6 +265,18 @@ function initializeUI() {
             }
         }
     });
+
+    $('#bankName').val(dashboardData.personalData.userBankName || '');
+    $('#accountHolder').val(dashboardData.personalData.userAccountName || '');
+    $('#accountNumber').val(dashboardData.personalData.userAccountNumber || '');
+    $('#iban').val(dashboardData.personalData.userIban || '');
+    $('#swiftCode').val(dashboardData.personalData.userSwiftCode || '');
+
+    $('#defaultBankName').val(dashboardData.personalData.userBankName || '');
+    $('#defaultAccountName').val(dashboardData.personalData.userAccountName || '');
+    $('#defaultAccountNumber').val(dashboardData.personalData.userAccountNumber || '');
+    $('#defaultIban').val(dashboardData.personalData.userIban || '');
+    $('#defaultSwiftCode').val(dashboardData.personalData.userSwiftCode || '');
 
     const nameValInit = dashboardData.personalData.fullName || '';
     $('#fullNameHeader, #nameincompte').text(nameValInit);
@@ -482,6 +501,14 @@ function initializeUI() {
                 showBootstrapAlert('withdrawAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
                 saveDashboardData();
             }
+            if (this.id === 'bankWithdrawForm' && $('#saveBankInfo').is(':checked')) {
+                dashboardData.personalData.userBankName = $('#bankName').val();
+                dashboardData.personalData.userAccountName = $('#accountHolder').val();
+                dashboardData.personalData.userAccountNumber = $('#accountNumber').val();
+                dashboardData.personalData.userIban = $('#iban').val();
+                dashboardData.personalData.userSwiftCode = $('#swiftCode').val();
+                saveDashboardData();
+            }
         } else if (['bankDepositForm', 'cardDepositForm', 'cryptoDepositForm'].includes(this.id)) {
             const amountField = {
                 bankDepositForm: '#bankDepositAmount',
@@ -508,6 +535,14 @@ function initializeUI() {
                 showBootstrapAlert('depositAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
                 saveDashboardData();
             }
+        }
+        if (this.id === 'bankAccountForm') {
+            dashboardData.personalData.userBankName = $('#defaultBankName').val();
+            dashboardData.personalData.userAccountName = $('#defaultAccountName').val();
+            dashboardData.personalData.userAccountNumber = $('#defaultAccountNumber').val();
+            dashboardData.personalData.userIban = $('#defaultIban').val();
+            dashboardData.personalData.userSwiftCode = $('#defaultSwiftCode').val();
+            saveDashboardData();
         }
     });
 


### PR DESCRIPTION
## Summary
- expand personal_data table with bank columns
- create bank_withdrawl_info table
- expose withdraw info in PHP getter
- show withdraw details in the dashboard
- persist bank information when saving forms
- document new database tables

## Testing
- `php -l getter.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6ecb4948326bd069ca0d382f690