### PR TITLE
Fix history ordering

### DIFF
--- a/getter.php
+++ b/getter.php
@@ -19,12 +19,12 @@ $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 $data = [
     'personalData' => $personal,
     'wallets' => fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]),
-    'transactions' => fetchAll($pdo, 'SELECT operationNumber,type,amount,date,status,statusClass FROM transactions WHERE user_id = ? ORDER BY id DESC LIMIT 10', [$userId]),
+    'transactions' => fetchAll($pdo, 'SELECT operationNumber,type,amount,date,status,statusClass FROM transactions WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'notifications' => fetchAll($pdo, 'SELECT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC', [$userId]),
-    'deposits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY id DESC LIMIT 10', [$userId]),
-    'retraits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY id DESC LIMIT 10', [$userId]),
+    'deposits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
+    'retraits' => fetchAll($pdo, 'SELECT date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'tradingHistory' => fetchAll($pdo, 'SELECT temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass FROM tradingHistory WHERE user_id = ? ORDER BY id DESC LIMIT 5', [$userId]),
-    'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC', [$userId]),
     'bankWithdrawInfo' => $bankWithdraw,
     // placeholders for front-end
     'formData' => new stdClass(),

--- a/script.js
+++ b/script.js
@@ -736,6 +736,7 @@ function initializeUI() {
         const $tbodyDeposits = $('#historiqueDepots');
         $tbodyDeposits.empty();
         if (dashboardData.deposits?.length > 0) {
+            dashboardData.deposits.sort((a, b) => new Date(b.date) - new Date(a.date));
             dashboardData.deposits.slice(0, 10).forEach(d => {
                 $tbodyDeposits.append(`
                     <tr>
@@ -754,6 +755,7 @@ function initializeUI() {
         const $tbodyRetraits = $('#historiqueRetraits');
         $tbodyRetraits.empty();
         if (dashboardData.retraits?.length > 0) {
+            dashboardData.retraits.sort((a, b) => new Date(b.date) - new Date(a.date));
             dashboardData.retraits.slice(0, 10).forEach(r => {
                 $tbodyRetraits.append(`
                     <tr>


### PR DESCRIPTION
## Summary
- order deposit, withdrawal, transaction and login history queries by parsed date
- sort deposit and withdrawal history in the dashboard before showing

## Testing
- `node --check script.js`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff59a0748832685c7a22476f8ca45