### PR TITLE
Add success alert after bank account update

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1050,6 +1050,7 @@
 <div class="alert alert-info">
 <i class="fas fa-info-circle me-2"></i> Ces informations seront utilisées pour les retraits automatiques.
                       </div>
+<div id="bankAccountAlert"></div>
 <form id="bankAccountForm">
 <div class="mb-3">
 <label class="form-label" for="defaultBankName">Nom de la banque</label>

--- a/script.js
+++ b/script.js
@@ -586,7 +586,7 @@ function initializeUI() {
             $('#iban').val($('#defaultIban').val());
             $('#swiftCode').val($('#defaultSwiftCode').val());
             saveDashboardData();
-            showBootstrapAlert('withdrawAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
+            showBootstrapAlert('bankAccountAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
         }
     });
 


### PR DESCRIPTION
## Summary
- add `bankAccountAlert` container to profile form
- show success message in new alert after submitting bank account changes

## Testing
- `php -l getter.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860561cd0508326af782470ee618d40