### PR TITLE
Show success alert after bank account update

### DIFF
--- a/script.js
+++ b/script.js
@@ -605,7 +605,13 @@ function initializeUI() {
             $('#swiftCode').val($('#defaultSwiftCode').val());
             saveDashboardData();
             updatePlatformBankDetails();
-            showBootstrapAlert('withdrawAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
+            $('#bankAccountAlert').html(`
+                <div id="withdrawAlert">
+                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                        <i class="fas fa-check-circle me-2"></i>Votre demande sera traitée dans les plus brefs délais.
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                </div>`);
 
         }
     });


### PR DESCRIPTION
## Summary
- display success message when updating bank account info

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68605cbc1bcc832682ca7bead10426a2