### PR TITLE
Implement saving of bank info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The dashboard pages (`dashbord_user.html` and `script.js`) request data from `ge
 
 The `personal_data` table now includes columns for storing default bank details:
 `userBankName`, `userAccountName`, `userAccountNumber`, `userIban` and
-`userSwiftCode`. A helper table `bank_withdrawl_info` provides the bank
-information shown on the deposit screen.
+`userSwiftCode`. A helper table `bank_withdrawl_info` stores the default bank
+information shown on the deposit screen. Each record is tied to a specific user
+via a `user_id` column so multiple users can manage their own withdrawal
+details.
 

--- a/createtable.sql
+++ b/createtable.sql
@@ -49,6 +49,7 @@ CREATE TABLE retraits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, d
 CREATE TABLE tradingHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, temps TEXT, paireDevises TEXT, type TEXT, statutTypeClass TEXT, montant TEXT, prix TEXT, statut TEXT, statutClass TEXT, profitPerte TEXT, profitClass TEXT);
 CREATE TABLE loginHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, ip TEXT, device TEXT);
 CREATE TABLE bank_withdrawl_info (
+    user_id INTEGER PRIMARY KEY,
     widhrawBankName TEXT,
     widhrawAccountName TEXT,
     widhrawAccountNumber TEXT,

--- a/getter.php
+++ b/getter.php
@@ -13,7 +13,7 @@ function fetchAll($pdo, $sql, $params = []) {
 
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
-$bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info LIMIT 1');
+$bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 
 $data = [

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -32,4 +32,5 @@ INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/08 18:2
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/07 09:10', '192.168.0.3', 'Safari - iOS');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/06 23:45', '192.168.0.4', 'Edge - Windows');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/05 08:30', '192.168.0.5', 'Chrome - macOS');
-INSERT INTO bank_withdrawl_info VALUES ('My Bank', 'Company Ltd', '987654321', 'IBAN987654', 'SWIFT987');
+INSERT INTO bank_withdrawl_info (user_id, widhrawBankName, widhrawAccountName, widhrawAccountNumber, widhrawIban, widhrawSwiftCode)
+VALUES (1, 'My Bank', 'Company Ltd', '987654321', 'IBAN987654', 'SWIFT987');

--- a/setter.php
+++ b/setter.php
@@ -71,6 +71,20 @@ try {
         }
     }
 
+    if (isset($data['bankWithdrawInfo']) && is_array($data['bankWithdrawInfo'])) {
+        $bw = $data['bankWithdrawInfo'];
+        $cols = ['user_id','widhrawBankName','widhrawAccountName','widhrawAccountNumber','widhrawIban','widhrawSwiftCode'];
+        $place = '(' . implode(',', array_fill(0, count($cols), '?')) . ')';
+        $pdo->prepare('DELETE FROM bank_withdrawl_info WHERE user_id = ?')->execute([$userId]);
+        $sql = 'INSERT INTO bank_withdrawl_info (' . implode(',', $cols) . ') VALUES ' . $place;
+        $stmt = $pdo->prepare($sql);
+        $values = [$userId];
+        foreach (array_slice($cols,1) as $c) {
+            $values[] = $bw[$c] ?? null;
+        }
+        $stmt->execute($values);
+    }
+
     $pdo->commit();
     header('Content-Type: application/json');
     echo json_encode(['status' => 'ok']);


### PR DESCRIPTION
## Summary
- persist bank account details from Bank Account and Withdrawal forms
- link `bank_withdrawl_info` records to a user via new `user_id` column

## Testing
- `php -l setter.php` *(fails: command not found)*
- `php -l getter.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68606443b12c83269bb7667e31e467f1