### PR TITLE
Load all user wallets

### DIFF
--- a/getter.php
+++ b/getter.php
@@ -13,6 +13,8 @@ function fetchAll($pdo, $sql, $params = []) {
 
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
+$wallets = fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]);
+$personal['wallets'] = $wallets;
 $bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 

--- a/script.js
+++ b/script.js
@@ -51,6 +51,9 @@ async function fetchDashboardData() {
     try {
         const res = await fetch('getter.php?user_id=' + encodeURIComponent(userId));
         dashboardData = await res.json();
+        if (dashboardData.wallets && !dashboardData.personalData.wallets) {
+            dashboardData.personalData.wallets = dashboardData.wallets;
+        }
         console.log("Fetched dashboard data", dashboardData);
         updatePlatformBankDetails();
         initializeUI();


### PR DESCRIPTION
## Summary
- return saved wallets with personal data
- merge fetched wallets into dashboard data on the client

## Testing
- `php -l getter.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686069a488f88326ad45b0ea117dc076