### PR TITLE
Add wallet endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project uses small PHP helpers (`getter.php` and `setter.php`) to read and 
 3. The PHP scripts connect to `coin_db` on `localhost` using the `root` user with an empty password. Update the connection settings in `getter.php` and `setter.php` if your environment differs.
 
 The dashboard pages (`dashbord_user.html` and `script.js`) request data from `getter.php` and send updates to `setter.php`.
+`script.js` now fetches wallet addresses from `get_wallets.php`, which returns `SELECT * FROM wallets WHERE user_id = ?` in JSON.
 
 The `personal_data` table now includes columns for storing default bank details:
 `userBankName`, `userAccountName`, `userAccountNumber`, `userIban` and

--- a/get_wallets.php
+++ b/get_wallets.php
@@ -1,0 +1,12 @@
+<?php
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
+$stmt = $pdo->prepare('SELECT * FROM wallets WHERE user_id = ?');
+$stmt->execute([$userId]);
+$wallets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+header('Content-Type: application/json');
+echo json_encode($wallets);

--- a/script.js
+++ b/script.js
@@ -65,7 +65,7 @@ function renderWalletTable(wallets = dashboardData.personalData.wallets || []) {
 
 async function fetchWallets() {
     try {
-        const res = await fetch('getter.php?user_id=' + encodeURIComponent(userId));
+        const res = await fetch('get_wallets.php?user_id=' + encodeURIComponent(userId));
         const data = await res.json();
         dashboardData.personalData.wallets = data.wallets || [];
         renderWalletTable();


### PR DESCRIPTION
## Summary
- create `get_wallets.php` for retrieving wallet rows by `user_id`
- update `fetchWallets()` to use the new endpoint
- document the new endpoint in README

## Testing
- `php -l get_wallets.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686591e3482c8326a57dad6691e4ac96