### PR TITLE
Fix wallet endpoint to return wallets object

### DIFF
--- a/get_wallets.php
+++ b/get_wallets.php
@@ -9,4 +9,4 @@ $stmt->execute([$userId]);
 $wallets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 header('Content-Type: application/json');
-echo json_encode($wallets);
+echo json_encode(['wallets' => $wallets]);


### PR DESCRIPTION
## Summary
- adjust `get_wallets.php` to wrap returned wallet list in a `wallets` object

## Testing
- `php -l get_wallets.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cbf5003c8326b31c0f2261195682