### PR TITLE
Enable wallet edit/delete actions

### DIFF
--- a/get_wallets.php
+++ b/get_wallets.php
@@ -3,6 +3,43 @@ $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
 $pdo = new PDO($dsn, 'root', '');
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
+        exit;
+    }
+
+    $action = $data['action'] ?? '';
+    $userId = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+    $id = $data['id'] ?? null;
+
+    if (!$userId || !$id) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Missing parameters']);
+        exit;
+    }
+
+    if ($action === 'edit') {
+        $stmt = $pdo->prepare('UPDATE wallets SET address = ?, label = ? WHERE id = ? AND user_id = ?');
+        $stmt->execute([
+            $data['address'] ?? '',
+            $data['label'] ?? '',
+            $id,
+            $userId
+        ]);
+    } elseif ($action === 'delete') {
+        $stmt = $pdo->prepare('DELETE FROM wallets WHERE id = ? AND user_id = ?');
+        $stmt->execute([$id, $userId]);
+    }
+
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok']);
+    exit;
+}
+
 $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
 $stmt = $pdo->prepare('SELECT * FROM wallets WHERE user_id = ?');
 $stmt->execute([$userId]);

--- a/script.js
+++ b/script.js
@@ -745,8 +745,11 @@ function initializeUI() {
     $(document).on('click', '.wallet-delete', async function () {
         const id = $(this).data('id');
         if (confirm('Êtes-vous sûr de vouloir supprimer cette adresse ?')) {
-            dashboardData.personalData.wallets = (dashboardData.personalData.wallets || []).filter(w => w.id !== id);
-            await saveDashboardData();
+            await fetch('get_wallets.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'delete', id, user_id: userId })
+            });
             await fetchWallets();
         }
     });
@@ -769,11 +772,11 @@ function initializeUI() {
             alert('Veuillez saisir une adresse.');
             return;
         }
-        const wallet = (dashboardData.personalData.wallets || []).find(w => w.id === currentEditWalletId);
-        if (!wallet) return;
-        wallet.address = address;
-        wallet.label = label;
-        await saveDashboardData();
+        await fetch('get_wallets.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'edit', id: currentEditWalletId, address, label, user_id: userId })
+        });
         await fetchWallets();
         $('#editWalletModal').modal('hide');
     });


### PR DESCRIPTION
## Summary
- support POST actions in `get_wallets.php` so wallets can be edited or deleted
- update wallet handlers in `script.js` to call the new API

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6865d056ea3083268c14c385d77122c5