### PR TITLE
Fix escaping in dashboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,6 +21,15 @@ function formatDollar(num) {
     }) + ' $';
 }
 
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/'/g, '&#39;')
+        .replace(/"/g, '&quot;');
+}
+
 function showBootstrapAlert(containerId, message, type = 'success') {
     const icons = {
         success: 'fa-check-circle',
@@ -30,8 +39,8 @@ function showBootstrapAlert(containerId, message, type = 'success') {
     };
     const icon = icons[type] || icons.info;
     const alertHtml = `
-        <div class="alert alert-${type} alert-dismissible fade show" role="alert">
-            <i class="fas ${icon} me-2"></i>${message}
+        <div class="alert alert-${escapeHtml(type)} alert-dismissible fade show" role="alert">
+            <i class="fas ${icon} me-2"></i>${escapeHtml(message)}
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>`;
     $('#' + containerId).html(alertHtml);
@@ -50,13 +59,13 @@ function renderWalletTable(wallets = dashboardData.personalData.wallets || []) {
     const $tbody = $('#walletTableBody');
     $tbody.empty();
     wallets.forEach(w => {
-        const row = `<tr data-id="${w.id}">
-                <td>${currencyNames[w.currency] || w.currency}</td>
-                <td>${w.network}</td>
-                <td class="wallet-address">${w.address || '---'}</td>
+        const row = `<tr data-id="${escapeHtml(w.id)}">
+                <td>${escapeHtml(currencyNames[w.currency] || w.currency)}</td>
+                <td>${escapeHtml(w.network)}</td>
+                <td class="wallet-address">${escapeHtml(w.address || '---')}</td>
                 <td>
-                    <button class="btn btn-sm btn-outline-primary me-1 wallet-edit" data-id="${w.id}"><i class="fas fa-edit"></i></button>
-                    <button class="btn btn-sm btn-outline-danger wallet-delete" data-id="${w.id}"><i class="fas fa-trash"></i></button>
+                    <button class="btn btn-sm btn-outline-primary me-1 wallet-edit" data-id="${escapeHtml(w.id)}"><i class="fas fa-edit"></i></button>
+                    <button class="btn btn-sm btn-outline-danger wallet-delete" data-id="${escapeHtml(w.id)}"><i class="fas fa-trash"></i></button>
                 </td>
             </tr>`;
         $tbody.append(row);
@@ -204,13 +213,13 @@ function initializeUI() {
             const info = stepInfo[k] || { label: k, desc: '' };
             $history.append(`
                 <div class="timeline-item">
-                    <div class="timeline-date">${date || '-'}</div>
+                    <div class="timeline-date">${escapeHtml(date || '-')}</div>
                     <div class="timeline-content">
                         <div class="d-flex align-items-center mb-2">
-                            <span class="badge ${badgeClass} me-2">${statusTxt}</span>
-                            <h6 class="mb-0">${info.label}</h6>
+                            <span class="badge ${escapeHtml(badgeClass)} me-2">${escapeHtml(statusTxt)}</span>
+                            <h6 class="mb-0">${escapeHtml(info.label)}</h6>
                         </div>
-                        <p class="text-muted small">${info.desc}</p>
+                        <p class="text-muted small">${escapeHtml(info.desc)}</p>
                     </div>
                 </div>`);
         });
@@ -332,10 +341,10 @@ function initializeUI() {
     if (dashboardData.notifications?.length > 0) {
         dashboardData.notifications.forEach(n => {
             $notifications.append(`
-                <div class="alert ${n.alertClass}">
-                    <strong>${n.title}</strong>
-                    <p class="mb-0">${n.message}</p>
-                    <small>${n.time}</small>
+                <div class="alert ${escapeHtml(n.alertClass)}">
+                    <strong>${escapeHtml(n.title)}</strong>
+                    <p class="mb-0">${escapeHtml(n.message)}</p>
+                    <small>${escapeHtml(n.time)}</small>
                 </div>`);
         });
     } else {
@@ -367,11 +376,11 @@ function initializeUI() {
             dashboardData.transactions.slice(0, 5).forEach(t => {
                 $tbody.append(`
                     <tr>
-                        <td>${t.operationNumber}</td>
-                        <td>${t.type}</td>
-                        <td>${t.amount}</td>
-                        <td>${t.date}</td>
-                        <td><span class="badge ${t.statusClass}">${t.status}</span></td>
+                        <td>${escapeHtml(t.operationNumber)}</td>
+                        <td>${escapeHtml(t.type)}</td>
+                        <td>${escapeHtml(t.amount)}</td>
+                        <td>${escapeHtml(t.date)}</td>
+                        <td><span class="badge ${escapeHtml(t.statusClass)}">${escapeHtml(t.status)}</span></td>
                     </tr>`);
             });
         } else {
@@ -396,12 +405,12 @@ function initializeUI() {
                     <a class="dropdown-item" href="#">
                         <div class="d-flex">
                             <div class="flex-shrink-0">
-                                <i class="${iconClass}"></i>
+                                <i class="${escapeHtml(iconClass)}"></i>
                             </div>
                             <div class="flex-grow-1 ms-3">
-                                <div class="fw-bold">${notification.title}</div>
-                                <div class="small text-muted">${notification.message}</div>
-                                <div class="small text-muted">${notification.time}</div>
+                                <div class="fw-bold">${escapeHtml(notification.title)}</div>
+                                <div class="small text-muted">${escapeHtml(notification.message)}</div>
+                                <div class="small text-muted">${escapeHtml(notification.time)}</div>
                             </div>
                         </div>
                     </a>
@@ -661,7 +670,7 @@ function initializeUI() {
         const displayFile = (fileName) => {
             $area.html(`
                 <i class="fas fa-file-alt fa-3x mb-3"></i>
-                <h5>${fileName}</h5>
+                <h5>${escapeHtml(fileName)}</h5>
                 <p class="text-muted">Cliquez pour modifier le profil</p>`);
         };
         $area.on('click', () => $input.click());
@@ -706,7 +715,7 @@ function initializeUI() {
         const $net = $('#walletNetwork');
         $net.empty().append('<option value="">-- Choisissez le réseau --</option>');
         (networksByCurrency[currency] || []).forEach(n => {
-            $net.append(`<option value="${n}">${n}</option>`);
+            $net.append(`<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`);
         });
     }
 
@@ -718,7 +727,7 @@ function initializeUI() {
         if ($net.length === 0) return;
         $net.empty().append('<option value="">-- Choisissez le réseau --</option>');
         (networksByCurrency[currency] || []).forEach(n => {
-            $net.append(`<option value="${n}">${n}</option>`);
+            $net.append(`<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`);
         });
     }
 
@@ -817,10 +826,10 @@ function initializeUI() {
             dashboardData.deposits.slice(0, 10).forEach(d => {
                 $tbodyDeposits.append(`
                     <tr>
-                        <td>${d.date}</td>
-                        <td>${d.amount}</td>
-                        <td>${d.method}</td>
-                        <td><span class="badge ${d.statusClass}">${d.status}</span></td>
+                        <td>${escapeHtml(d.date)}</td>
+                        <td>${escapeHtml(d.amount)}</td>
+                        <td>${escapeHtml(d.method)}</td>
+                        <td><span class="badge ${escapeHtml(d.statusClass)}">${escapeHtml(d.status)}</span></td>
                     </tr>`);
             });
         } else {
@@ -836,10 +845,10 @@ function initializeUI() {
             dashboardData.retraits.slice(0, 10).forEach(r => {
                 $tbodyRetraits.append(`
                     <tr>
-                        <td>${r.date}</td>
-                        <td>${r.amount}</td>
-                        <td>${r.method}</td>
-                        <td><span class="badge ${r.statusClass}">${r.status}</span></td>
+                        <td>${escapeHtml(r.date)}</td>
+                        <td>${escapeHtml(r.amount)}</td>
+                        <td>${escapeHtml(r.method)}</td>
+                        <td><span class="badge ${escapeHtml(r.statusClass)}">${escapeHtml(r.status)}</span></td>
                     </tr>`);
             });
         } else {
@@ -871,13 +880,13 @@ function initializeUI() {
             dashboardData.tradingHistory.slice(0, 5).forEach(trade => {
                 $tbodyTrading.append(`
                     <tr>
-                        <td>${trade.temps}</td>
-                        <td>${trade.paireDevises}</td>
-                        <td><span class="badge ${trade.statutTypeClass}">${trade.type}</span></td>
-                        <td>${trade.montant}</td>
-                        <td>${trade.prix}</td>
-                        <td><span class="badge ${trade.statutClass}">${trade.statut}</span></td>
-                        <td class="${trade.profitClass || ''}">${trade.profitPerte}</td>
+                        <td>${escapeHtml(trade.temps)}</td>
+                        <td>${escapeHtml(trade.paireDevises)}</td>
+                        <td><span class="badge ${escapeHtml(trade.statutTypeClass)}">${escapeHtml(trade.type)}</span></td>
+                        <td>${escapeHtml(trade.montant)}</td>
+                        <td>${escapeHtml(trade.prix)}</td>
+                        <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
+                        <td class="${escapeHtml(trade.profitClass || '')}">${escapeHtml(trade.profitPerte)}</td>
                     </tr>`);
             });
         } else {
@@ -1188,9 +1197,9 @@ function initializeUI() {
         dashboardData.loginHistory.slice(0, 5).forEach(h => {
             $loginHistoryBody.append(`
                 <tr>
-                    <td>${h.date}</td>
-                    <td>${h.ip}</td>
-                    <td>${h.device}</td>
+                    <td>${escapeHtml(h.date)}</td>
+                    <td>${escapeHtml(h.ip)}</td>
+                    <td>${escapeHtml(h.device)}</td>
                 </tr>`);
         });
     } else {


### PR DESCRIPTION
## Summary
- add escapeHtml() utility
- sanitize dynamic HTML in script.js
- ensure wallet, notifications, transactions and history use escaping

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6865d5ca61ac8326b07a9c9f425e79f6