### PR TITLE
Reset wallet edit ID when modal closes

### DIFF
--- a/script.js
+++ b/script.js
@@ -774,6 +774,10 @@ function initializeUI() {
         $('#editWalletModal').modal('show');
     });
 
+    $('#editWalletModal').on('hidden.bs.modal', function () {
+        currentEditWalletId = null;
+    });
+
     $('#saveWalletEditBtn').on('click', async function () {
         const address = $('#editWalletAddress').val().trim();
         const label = $('#editWalletLabel').val().trim();


### PR DESCRIPTION
## Summary
- clear `currentEditWalletId` once the edit wallet modal is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d7396f9c83268c8f36319f2649c7