### PR TITLE
Add wallet edit popup alerts

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1217,6 +1217,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
       </div>
       <div class="modal-body">
+        <div id="editWalletAlert"></div>
         <form id="editWalletForm">
           <div class="mb-3">
             <label class="form-label" for="editWalletAddress">Adresse du portefeuille</label>

--- a/script.js
+++ b/script.js
@@ -776,22 +776,32 @@ function initializeUI() {
 
     $('#editWalletModal').on('hidden.bs.modal', function () {
         currentEditWalletId = null;
+        $('#editWalletAlert').empty();
     });
 
     $('#saveWalletEditBtn').on('click', async function () {
         const address = $('#editWalletAddress').val().trim();
         const label = $('#editWalletLabel').val().trim();
         if (!address) {
-            alert('Veuillez saisir une adresse.');
+            showBootstrapAlert('editWalletAlert', 'Veuillez saisir une adresse.', 'danger');
             return;
         }
-        await fetch('get_wallets.php', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action: 'edit', id: currentEditWalletId, address, label, user_id: userId })
-        });
-        await fetchWallets();
-        $('#editWalletModal').modal('hide');
+        try {
+            const res = await fetch('get_wallets.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'edit', id: currentEditWalletId, address, label, user_id: userId })
+            });
+            const result = await res.json();
+            if (!res.ok || result.status !== 'ok') {
+                throw new Error(result.message || 'Erreur lors de la mise \u00e0 jour');
+            }
+            await fetchWallets();
+            showBootstrapAlert('editWalletAlert', 'Adresse mise \u00e0 jour avec succ\u00e8s.', 'success');
+            setTimeout(() => $('#editWalletModal').modal('hide'), 1000);
+        } catch (err) {
+            showBootstrapAlert('editWalletAlert', err.message || 'Erreur lors de la mise \u00e0 jour', 'danger');
+        }
     });
 
     $('#addWalletBtn').on('click', async function () {


### PR DESCRIPTION
## Summary
- add an alert container to wallet edit modal
- show success or error messages when saving an edited wallet
- clear the alert when the modal is closed

## Testing
- `php -l get_wallets.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68666cc074f083268bec43eadfaa7950