### PR TITLE
Add admin accounts table and link to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ information shown on the deposit screen. Each record is tied to a specific user
 via a `user_id` column so multiple users can manage their own withdrawal
 details.
 
+An additional table `admins_agents` stores admin and agent accounts. Each row
+contains an email, hashed password and an `is_admin` flag, plus a `created_by`
+field referencing the admin who created the record. The `personal_data` table
+now includes a `linked_to_id` column storing the `admins_agents.id` of the
+creator.
+
 ## Wallet management
 
 Each wallet row includes edit and delete icons. Clicking the **edit** icon opens

--- a/createtable.sql
+++ b/createtable.sql
@@ -29,7 +29,8 @@ CREATE TABLE personal_data (
     userAccountName TEXT,
     userAccountNumber TEXT,
     userIban TEXT,
-    userSwiftCode TEXT
+    userSwiftCode TEXT,
+    linked_to_id INTEGER
 );
 
 
@@ -55,4 +56,12 @@ CREATE TABLE bank_withdrawl_info (
     widhrawAccountNumber TEXT,
     widhrawIban TEXT,
     widhrawSwiftCode TEXT
+);
+
+CREATE TABLE admins_agents (
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    email TEXT NOT NULL,
+    password TEXT NOT NULL,
+    is_admin TINYINT(1) NOT NULL,
+    created_by INTEGER NULL
 );

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -1,4 +1,7 @@
-INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123');
+INSERT INTO admins_agents (email, password, is_admin, created_by)
+VALUES ('admin@example.com', 'hashed_password_here', 1, NULL);
+
+INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123', 1);
 
 INSERT INTO wallets VALUES (
     1751038645430, 1, 'btc', 'Bitcoin',


### PR DESCRIPTION
## Summary
- add `admins_agents` table and reference from `personal_data`
- insert default admin record
- document admin table and `linked_to_id` column

## Testing
- `php -l getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b6507688326acd109b50070cf57