### PR TITLE
Add admin management endpoints

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -1,0 +1,35 @@
+<?php
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$adminId = isset($_GET['admin_id']) ? (int)$_GET['admin_id'] : 0;
+if (!$adminId) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Missing admin_id']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+$stmt->execute([$adminId]);
+$admin = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$admin) {
+    http_response_code(404);
+    echo json_encode(['status' => 'error', 'message' => 'Admin not found']);
+    exit;
+}
+
+$result = [];
+
+if ((int)$admin['is_admin'] === 1) {
+    $stmt = $pdo->prepare('SELECT id,email,is_admin,created_by FROM admins_agents WHERE created_by = ?');
+    $stmt->execute([$adminId]);
+    $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$stmt = $pdo->prepare('SELECT * FROM personal_data WHERE linked_to_id = ?');
+$stmt->execute([$adminId]);
+$result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/admin_setter.php
+++ b/admin_setter.php
@@ -1,0 +1,49 @@
+<?php
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
+    exit;
+}
+
+$action = $data['action'] ?? '';
+
+try {
+    if ($action === 'create_admin') {
+        $email = $data['email'] ?? '';
+        $password = $data['password'] ?? '';
+        $isAdmin = isset($data['is_admin']) ? (int)$data['is_admin'] : 0;
+        $createdBy = $data['created_by'] ?? null;
+        if (!$email || !$password) {
+            throw new Exception('Missing parameters');
+        }
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO admins_agents (email, password, is_admin, created_by) VALUES (?,?,?,?)');
+        $stmt->execute([$email, $hash, $isAdmin, $createdBy]);
+        echo json_encode(['status' => 'ok', 'id' => $pdo->lastInsertId()]);
+    } elseif ($action === 'create_user') {
+        $user = $data['user'] ?? [];
+        if (!$user || !isset($user['linked_to_id']) || !isset($user['password'])) {
+            throw new Exception('Missing parameters');
+        }
+        $password = $user['password'];
+        unset($user['password']);
+        $user['passwordHash'] = password_hash($password, PASSWORD_DEFAULT);
+        $cols = array_keys($user);
+        $place = implode(',', array_fill(0, count($cols), '?'));
+        $sql = 'INSERT INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($user));
+        echo json_encode(['status' => 'ok']);
+    } else {
+        throw new Exception('Invalid action');
+    }
+} catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -268,65 +268,8 @@
                                                 <th>Actions</th>
                                             </tr>
                                         </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>#001</td>
-                                                <td>Marie Dupont</td>
-                                                <td>marie.dupont@email.com</td>
-                                                <td><span class="badge bg-primary">Utilisateur</span></td>
-                                                <td><span class="badge bg-success">Actif</span></td>
-                                                <td>15/01/2025</td>
-                                                <td>
-                                                    <button class="btn btn-sm btn-outline-primary me-1">
-                                                        <i class="bi bi-eye"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-warning me-1">
-                                                        <i class="bi bi-pencil"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-danger">
-                                                        <i class="bi bi-trash"></i>
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>#002</td>
-                                                <td>Jean Martin</td>
-                                                <td>jean.martin@email.com</td>
-                                                <td><span class="badge bg-danger">Admin</span></td>
-                                                <td><span class="badge bg-success">Actif</span></td>
-                                                <td>12/01/2025</td>
-                                                <td>
-                                                    <button class="btn btn-sm btn-outline-primary me-1">
-                                                        <i class="bi bi-eye"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-warning me-1">
-                                                        <i class="bi bi-pencil"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-danger">
-                                                        <i class="bi bi-trash"></i>
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>#003</td>
-                                                <td>Sophie Bernard</td>
-                                                <td>sophie.bernard@email.com</td>
-                                                <td><span class="badge bg-primary">Utilisateur</span></td>
-                                                <td><span class="badge bg-warning">Suspendu</span></td>
-                                                <td>10/01/2025</td>
-                                                <td>
-                                                    <button class="btn btn-sm btn-outline-primary me-1">
-                                                        <i class="bi bi-eye"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-warning me-1">
-                                                        <i class="bi bi-pencil"></i>
-                                                    </button>
-                                                    <button class="btn btn-sm btn-outline-danger">
-                                                        <i class="bi bi-trash"></i>
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                        </tbody>
+                                        <tbody id="usersTableBody">
+</tbody>
                                     </table>
                                 </div>
                             </div>
@@ -683,37 +626,106 @@
                     document.getElementById(targetSection + '-section').classList.add('active');
                 });
             });
+            loadAdminData();
         });
         
+        const ADMIN_ID = 1;
+
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/'/g, '&#39;')
+                .replace(/"/g, '&quot;');
+        }
+
+        async function loadAdminData() {
+            try {
+                const res = await fetch('admin_getter.php?admin_id=' + ADMIN_ID);
+                const data = await res.json();
+                const tbody = document.getElementById('usersTableBody');
+                tbody.innerHTML = '';
+                const users = data.users || [];
+                if (users.length === 0) {
+                    tbody.innerHTML = '<tr><td colspan="7" class="text-center">Aucune donnée disponible</td></tr>';
+                    return;
+                }
+                users.forEach(u => {
+                    const row = `<tr>
+                        <td>${escapeHtml(u.user_id)}</td>
+                        <td>${escapeHtml(u.fullName || '')}</td>
+                        <td>${escapeHtml(u.emailaddress || '')}</td>
+                        <td><span class="badge bg-primary">Utilisateur</span></td>
+                        <td><span class="badge bg-success">Actif</span></td>
+                        <td></td>
+                        <td></td>
+                    </tr>`;
+                    tbody.insertAdjacentHTML('beforeend', row);
+                });
+            } catch (err) {
+                console.error('Failed to load admin data', err);
+            }
+        }
+
         // Create user functionality
-        function createUser() {
+        async function createUser() {
             const form = document.getElementById('createUserForm');
-            const formData = new FormData(form);
-            
-            // Basic validation
+
             const password = document.getElementById('password').value;
             const confirmPassword = document.getElementById('confirmPassword').value;
-            
             if (password !== confirmPassword) {
                 alert('Les mots de passe ne correspondent pas!');
                 return;
             }
-            
-            // Simulate user creation
-            alert('Utilisateur créé avec succès!');
-            
-            // Reset form and close modal
-            form.reset();
-            const modal = bootstrap.Modal.getInstance(document.getElementById('createUserModal'));
-            modal.hide();
-            
-            // You would typically send this data to your backend here
-            console.log('Création d\'utilisateur:', {
-                firstName: document.getElementById('firstName').value,
-                lastName: document.getElementById('lastName').value,
-                email: document.getElementById('email').value,
-                role: document.getElementById('role').value
-            });
+
+            const role = document.getElementById('role').value;
+            const firstName = document.getElementById('firstName').value.trim();
+            const lastName = document.getElementById('lastName').value.trim();
+            const email = document.getElementById('email').value.trim();
+
+            let payload;
+            if (role === 'user') {
+                payload = {
+                    action: 'create_user',
+                    user: {
+                        user_id: Date.now(),
+                        fullName: firstName + ' ' + lastName,
+                        emailaddress: email,
+                        password: password,
+                        linked_to_id: ADMIN_ID
+                    }
+                };
+            } else {
+                payload = {
+                    action: 'create_admin',
+                    email: email,
+                    password: password,
+                    is_admin: 1,
+                    created_by: ADMIN_ID
+                };
+            }
+
+            try {
+                const res = await fetch('admin_setter.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const result = await res.json();
+                if (result.status === 'ok') {
+                    alert('Utilisateur créé avec succès!');
+                    form.reset();
+                    const modal = bootstrap.Modal.getInstance(document.getElementById('createUserModal'));
+                    modal.hide();
+                    loadAdminData();
+                } else {
+                    alert('Erreur lors de la création');
+                }
+            } catch (err) {
+                console.error('Creation failed', err);
+                alert('Erreur lors de la création');
+            }
         }
         
         // Add some interactive features


### PR DESCRIPTION
## Summary
- add PHP endpoint for retrieving admin and user data
- add PHP endpoint for creating admins and users
- populate user list on the admin dashboard via new endpoints

## Testing
- `php -l admin_getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669c4497848326ae9d38e93d4650cd