### PR TITLE
Add agent management features

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -19,7 +19,9 @@ if (!$admin) {
     exit;
 }
 
-$result = [];
+$result = [
+    'is_admin' => (int)$admin['is_admin'],
+];
 
 if ((int)$admin['is_admin'] === 1) {
     $stmt = $pdo->prepare('SELECT id,email,is_admin,created_by FROM admins_agents WHERE created_by = ?');

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -86,6 +86,12 @@
                                 Utilisateurs
                             </a>
                         </li>
+                        <li class="nav-item mb-2" id="agentsNavItem" style="display:none;">
+                            <a href="#" class="nav-link" data-section="agents">
+                                <i class="bi bi-person-badge me-2"></i>
+                                Agents
+                            </a>
+                        </li>
                         <li class="nav-item mb-2">
                             <a href="#" class="nav-link" data-section="transactions">
                                 <i class="bi bi-credit-card me-2"></i>
@@ -213,6 +219,10 @@
                                                 <i class="bi bi-person-plus me-2"></i>
                                                 Créer Utilisateur
                                             </button>
+                                            <button class="btn btn-primary" id="createAgentQuickBtn" style="display:none;" data-bs-toggle="modal" data-bs-target="#createAgentModal">
+                                                <i class="bi bi-person-badge me-2"></i>
+                                                Créer Agent
+                                            </button>
                                             <button class="btn btn-outline-primary" data-section="kyc">
                                                 <i class="bi bi-person-check me-2"></i>
                                                 Vérifier KYC
@@ -293,6 +303,37 @@
                                         </li>
                                     </ul>
                                 </nav>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Agents Section -->
+                    <div id="agents-section" class="content-section">
+                        <div class="d-flex justify-content-between align-items-center mb-4">
+                            <h3>Gestion des Agents</h3>
+                            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createAgentModal">
+                                <i class="bi bi-person-badge me-2"></i>
+                                Créer Agent
+                            </button>
+                        </div>
+
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="mb-0">Liste des Agents</h5>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-hover mb-0">
+                                        <thead>
+                                            <tr>
+                                                <th>ID</th>
+                                                <th>Email</th>
+                                                <th>Rôle</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="agentsTableBody"></tbody>
+                                    </table>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -544,6 +585,40 @@
             </div>
         </div>
     </div>
+
+    <!-- Create Agent Modal -->
+    <div class="modal fade" id="createAgentModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Créer un Nouvel Agent</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="createAgentForm">
+                        <div class="mb-3">
+                            <label for="agentEmail" class="form-label">Email</label>
+                            <input type="email" class="form-control" id="agentEmail" required>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="agentPassword" class="form-label">Mot de Passe</label>
+                                <input type="password" class="form-control" id="agentPassword" required>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="agentConfirm" class="form-label">Confirmer le Mot de Passe</label>
+                                <input type="password" class="form-control" id="agentConfirm" required>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="button" class="btn btn-primary" onclick="createAgent()">Créer Agent</button>
+                </div>
+            </div>
+        </div>
+    </div>
     
     <!-- KYC Details Modal -->
     <div class="modal fade" id="kycModal" tabindex="-1">
@@ -630,6 +705,7 @@
         });
         
         const ADMIN_ID = 1;
+        let IS_ADMIN = 0;
 
         function escapeHtml(str) {
             return String(str)
@@ -644,25 +720,49 @@
             try {
                 const res = await fetch('admin_getter.php?admin_id=' + ADMIN_ID);
                 const data = await res.json();
+                IS_ADMIN = parseInt(data.is_admin || 0);
+
+                document.getElementById('agentsNavItem').style.display = IS_ADMIN ? 'block' : 'none';
+                const quickBtn = document.getElementById('createAgentQuickBtn');
+                if (quickBtn) quickBtn.style.display = IS_ADMIN ? 'block' : 'none';
+
                 const tbody = document.getElementById('usersTableBody');
                 tbody.innerHTML = '';
                 const users = data.users || [];
                 if (users.length === 0) {
                     tbody.innerHTML = '<tr><td colspan="7" class="text-center">Aucune donnée disponible</td></tr>';
-                    return;
+                } else {
+                    users.forEach(u => {
+                        const row = `<tr>
+                            <td>${escapeHtml(u.user_id)}</td>
+                            <td>${escapeHtml(u.fullName || '')}</td>
+                            <td>${escapeHtml(u.emailaddress || '')}</td>
+                            <td><span class="badge bg-primary">Utilisateur</span></td>
+                            <td><span class="badge bg-success">Actif</span></td>
+                            <td></td>
+                            <td></td>
+                        </tr>`;
+                        tbody.insertAdjacentHTML('beforeend', row);
+                    });
                 }
-                users.forEach(u => {
-                    const row = `<tr>
-                        <td>${escapeHtml(u.user_id)}</td>
-                        <td>${escapeHtml(u.fullName || '')}</td>
-                        <td>${escapeHtml(u.emailaddress || '')}</td>
-                        <td><span class="badge bg-primary">Utilisateur</span></td>
-                        <td><span class="badge bg-success">Actif</span></td>
-                        <td></td>
-                        <td></td>
-                    </tr>`;
-                    tbody.insertAdjacentHTML('beforeend', row);
-                });
+
+                const agentsBody = document.getElementById('agentsTableBody');
+                if (agentsBody) {
+                    agentsBody.innerHTML = '';
+                    const agents = data.agents || [];
+                    if (agents.length === 0) {
+                        agentsBody.innerHTML = '<tr><td colspan="3" class="text-center">Aucune donnée disponible</td></tr>';
+                    } else {
+                        agents.forEach(a => {
+                            const row = `<tr>
+                                <td>${escapeHtml(a.id)}</td>
+                                <td>${escapeHtml(a.email)}</td>
+                                <td><span class="badge bg-secondary">Agent</span></td>
+                            </tr>`;
+                            agentsBody.insertAdjacentHTML('beforeend', row);
+                        });
+                    }
+                }
             } catch (err) {
                 console.error('Failed to load admin data', err);
             }
@@ -717,6 +817,43 @@
                     alert('Utilisateur créé avec succès!');
                     form.reset();
                     const modal = bootstrap.Modal.getInstance(document.getElementById('createUserModal'));
+                    modal.hide();
+                    loadAdminData();
+                } else {
+                    alert('Erreur lors de la création');
+                }
+            } catch (err) {
+                console.error('Creation failed', err);
+                alert('Erreur lors de la création');
+            }
+        }
+
+        async function createAgent() {
+            const email = document.getElementById('agentEmail').value.trim();
+            const pass = document.getElementById('agentPassword').value;
+            const confirm = document.getElementById('agentConfirm').value;
+            if (pass !== confirm) {
+                alert('Les mots de passe ne correspondent pas!');
+                return;
+            }
+            const payload = {
+                action: 'create_admin',
+                email: email,
+                password: pass,
+                is_admin: 0,
+                created_by: ADMIN_ID
+            };
+            try {
+                const res = await fetch('admin_setter.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const result = await res.json();
+                if (result.status === 'ok') {
+                    alert('Agent créé avec succès!');
+                    document.getElementById('createAgentForm').reset();
+                    const modal = bootstrap.Modal.getInstance(document.getElementById('createAgentModal'));
                     modal.hide();
                     loadAdminData();
                 } else {


### PR DESCRIPTION
## Summary
- expose `is_admin` flag in `admin_getter.php`
- extend admin dashboard with agent management section and modal
- include quick action and navigation for creating agents

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b4cb70ac8326a968f29890a9b1de