### PR TITLE
Update hashed password and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ An additional table `admins_agents` stores admin and agent accounts. Each row
 contains an email, hashed password and an `is_admin` flag, plus a `created_by`
 field referencing the admin who created the record. The `personal_data` table
 now includes a `linked_to_id` column storing the `admins_agents.id` of the
-creator.
+creator. When inserting or updating these records via `admin_setter.php`, make
+sure the password you send is already hashed using PHP's `password_hash()`.
 
 ## Wallet management
 

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -1,5 +1,5 @@
 INSERT INTO admins_agents (email, password, is_admin, created_by)
-VALUES ('admin@example.com', 'hashed_password_here', 1, NULL);
+VALUES ('admin@example.com', '$2b$12$DujgN6sRcXHjyuXJkcTmgedBXpP9jwonqolpXmLOn2Z39RQS59EJa', 1, NULL);
 
 INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123', 1);
 


### PR DESCRIPTION
## Summary
- set a real hash for the sample admin account
- document that `admin_setter.php` expects hashed passwords

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866b66c66ac83268d1fb5373f1c3cb2