### PR TITLE
Document default admin and simplify admin getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ removes the wallet entirely. Edits and deletions are sent to
 `get_wallets.php`, and the wallet list refreshes immediately to show the latest
 data.
 
+## Admin dashboard
+
+`insertdata.sql` seeds a default administrator account (`admin@example.com`) with
+ID `1`. Opening `dashboard_admin.html` will automatically display this admin's
+data. `admin_getter.php` now defaults to ID `1` when no `admin_id` parameter is
+supplied, so you can browse the admin interface without logging in. Use the
+"Créer Agent" form to add new agents under the default admin.
+

--- a/admin_getter.php
+++ b/admin_getter.php
@@ -3,12 +3,7 @@ $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
 $pdo = new PDO($dsn, 'root', '');
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$adminId = isset($_GET['admin_id']) ? (int)$_GET['admin_id'] : 0;
-if (!$adminId) {
-    http_response_code(400);
-    echo json_encode(['status' => 'error', 'message' => 'Missing admin_id']);
-    exit;
-}
+$adminId = isset($_GET['admin_id']) ? (int)$_GET['admin_id'] : 1; // default admin
 
 $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
 $stmt->execute([$adminId]);

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -704,6 +704,7 @@
             loadAdminData();
         });
         
+        // Default administrator ID seeded in insertdata.sql
         const ADMIN_ID = 1;
         let IS_ADMIN = 0;
 


### PR DESCRIPTION
## Summary
- simplify `admin_getter.php` by defaulting to admin ID 1
- clarify admin usage in `dashboard_admin.html`
- document default admin login in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866f0d8a888832697a6793a1a9e09ac