### PR TITLE
Add user creation date

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -34,6 +34,9 @@ try {
         $password = $user['password'];
         unset($user['password']);
         $user['passwordHash'] = password_hash($password, PASSWORD_DEFAULT);
+        if (!isset($user['created_at']) || $user['created_at'] === '') {
+            $user['created_at'] = date('Y-m-d');
+        }
         $cols = array_keys($user);
         $place = implode(',', array_fill(0, count($cols), '?'));
         $sql = 'INSERT INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ')';

--- a/createtable.sql
+++ b/createtable.sql
@@ -22,6 +22,7 @@ CREATE TABLE personal_data (
     phone TEXT,
     dob TEXT,
     nationality TEXT,
+    created_at TEXT,
     btcAddress TEXT,
     ethAddress TEXT,
     usdtAddress TEXT,

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -749,8 +749,11 @@
                             <td>${escapeHtml(u.emailaddress || '')}</td>
                             <td><span class="badge bg-primary">Utilisateur</span></td>
                             <td><span class="badge bg-success">Actif</span></td>
-                            <td></td>
-                            <td></td>
+                            <td>${escapeHtml(u.created_at || '')}</td>
+                            <td>
+                                <button class="btn btn-sm btn-outline-primary me-1 user-edit" data-id="${escapeHtml(u.user_id)}"><i class="fas fa-edit"></i></button>
+                                <button class="btn btn-sm btn-outline-danger user-delete" data-id="${escapeHtml(u.user_id)}"><i class="fas fa-trash"></i></button>
+                            </td>
                         </tr>`;
                         tbody.insertAdjacentHTML('beforeend', row);
                     });

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -862,7 +862,7 @@
 </button>
 </div>
 <h5 class="mb-1" id="fullNameHeader">---</h5>
-<p class="text-muted mb-3">Membre depuis janvier 2025</p>
+<p class="text-muted mb-3" id="memberSince">Membre depuis janvier 2025</p>
 <div class="d-flex justify-content-center mb-2">
 <span class="badge bg-success me-2" id="compteverifie">---</span>
 <span class="badge bg-primary" id="niveauavance">---</span>

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -1,7 +1,7 @@
 INSERT INTO admins_agents (email, password, is_admin, created_by)
 VALUES ('admin@example.com', '$2b$12$DujgN6sRcXHjyuXJkcTmgedBXpP9jwonqolpXmLOn2Z39RQS59EJa', 1, NULL);
 
-INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123', 1);
+INSERT INTO personal_data VALUES (1, '3,500 $', '1200 $', '800 $', '10', 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', '0', '0', '0', '1', '0', '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000', '2025-06-11', 'ca', '2025-01-01', '0xABC123...', 'TRc123456...', 'Bank of Earth', 'Ahmed Kouraychi', 'ACC123456', 'IBAN123456', 'SWIFT123', 1);
 
 INSERT INTO wallets VALUES (
     1751038645430, 1, 'btc', 'Bitcoin',

--- a/script.js
+++ b/script.js
@@ -335,6 +335,12 @@ function initializeUI() {
     const nameValInit = dashboardData.personalData.fullName || '';
     $('#fullNameHeader, #nameincompte').text(nameValInit);
     $('#firstname').text(nameValInit.split(' ')[0] || nameValInit);
+    const createdAt = dashboardData.personalData.created_at;
+    if (createdAt) {
+        const dt = new Date(createdAt);
+        const monthYear = dt.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+        $('#memberSince').text('Membre depuis ' + monthYear);
+    }
     updateBalances();
 
     const $notifications = $('#notifications');


### PR DESCRIPTION
## Summary
- track user creation with a `created_at` column
- seed sample user with a creation date
- auto-set the date when admins create new users
- display user membership date in admin and user dashboards

## Testing
- `php -l admin_setter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b706fc048326a9c2e33adfb97d3f