### PR TITLE
Add admin user management actions

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -43,6 +43,31 @@ try {
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($user));
         echo json_encode(['status' => 'ok']);
+    } elseif ($action === 'update_user') {
+        $user = $data['user'] ?? [];
+        if (!$user || !isset($user['user_id'])) {
+            throw new Exception('Missing parameters');
+        }
+        $userId = (int)$user['user_id'];
+        unset($user['user_id']);
+        $cols = array_keys($user);
+        if (!$cols) {
+            throw new Exception('No fields to update');
+        }
+        $set = implode(',', array_map(fn($c) => "$c = ?", $cols));
+        $sql = "UPDATE personal_data SET $set WHERE user_id = ?";
+        $stmt = $pdo->prepare($sql);
+        $values = array_values($user);
+        $values[] = $userId;
+        $stmt->execute($values);
+        echo json_encode(['status' => 'ok']);
+    } elseif ($action === 'delete_user') {
+        $userId = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+        if (!$userId) {
+            throw new Exception('Missing user_id');
+        }
+        $pdo->prepare('DELETE FROM personal_data WHERE user_id = ?')->execute([$userId]);
+        echo json_encode(['status' => 'ok']);
     } else {
         throw new Exception('Invalid action');
     }

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -664,6 +664,52 @@
             </div>
         </div>
     </div>
+
+    <!-- View User Modal -->
+    <div class="modal fade" id="viewUserModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Détails Utilisateur</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Nom:</strong> <span id="viewFullName"></span></p>
+                    <p><strong>Email:</strong> <span id="viewEmail"></span></p>
+                    <p><strong>Date d'inscription:</strong> <span id="viewCreated"></span></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit User Modal -->
+    <div class="modal fade" id="editUserModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Modifier Utilisateur</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="editUserForm">
+                        <input type="hidden" id="editUserId">
+                        <div class="mb-3">
+                            <label for="editFullName" class="form-label">Nom complet</label>
+                            <input type="text" class="form-control" id="editFullName" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editEmail" class="form-label">Email</label>
+                            <input type="email" class="form-control" id="editEmail" required>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="button" class="btn btn-primary" id="saveEditUser">Enregistrer</button>
+                </div>
+            </div>
+        </div>
+    </div>
     
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -751,6 +797,7 @@
                             <td><span class="badge bg-success">Actif</span></td>
                             <td>${escapeHtml(u.created_at || '')}</td>
                             <td>
+                                <button class="btn btn-sm btn-outline-secondary me-1 user-view" data-id="${escapeHtml(u.user_id)}"><i class="fas fa-eye"></i></button>
                                 <button class="btn btn-sm btn-outline-primary me-1 user-edit" data-id="${escapeHtml(u.user_id)}"><i class="fas fa-edit"></i></button>
                                 <button class="btn btn-sm btn-outline-danger user-delete" data-id="${escapeHtml(u.user_id)}"><i class="fas fa-trash"></i></button>
                             </td>
@@ -879,7 +926,61 @@
                 alert('Erreur lors de la création');
             }
         }
-        
+
+        // User table actions
+        document.getElementById('usersTableBody').addEventListener('click', async function(e) {
+            const viewBtn = e.target.closest('.user-view');
+            const editBtn = e.target.closest('.user-edit');
+            const delBtn = e.target.closest('.user-delete');
+            if (viewBtn) {
+                const id = viewBtn.getAttribute('data-id');
+                const res = await fetch('getter.php?user_id=' + id);
+                const data = await res.json();
+                const pd = data.personalData || {};
+                document.getElementById('viewFullName').textContent = pd.fullName || '';
+                document.getElementById('viewEmail').textContent = pd.emailaddress || '';
+                document.getElementById('viewCreated').textContent = pd.created_at || '';
+                new bootstrap.Modal(document.getElementById('viewUserModal')).show();
+            } else if (editBtn) {
+                const id = editBtn.getAttribute('data-id');
+                const res = await fetch('getter.php?user_id=' + id);
+                const data = await res.json();
+                const pd = data.personalData || {};
+                document.getElementById('editUserId').value = id;
+                document.getElementById('editFullName').value = pd.fullName || '';
+                document.getElementById('editEmail').value = pd.emailaddress || '';
+                new bootstrap.Modal(document.getElementById('editUserModal')).show();
+            } else if (delBtn) {
+                const id = delBtn.getAttribute('data-id');
+                if (confirm('Supprimer cet utilisateur ?')) {
+                    await fetch('admin_setter.php', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ action: 'delete_user', user_id: id })
+                    });
+                    loadAdminData();
+                }
+            }
+        });
+
+        document.getElementById('saveEditUser').addEventListener('click', async function() {
+            const id = document.getElementById('editUserId').value;
+            const fullName = document.getElementById('editFullName').value.trim();
+            const email = document.getElementById('editEmail').value.trim();
+            const res = await fetch('admin_setter.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'update_user', user: { user_id: id, fullName: fullName, emailaddress: email } })
+            });
+            const result = await res.json();
+            if (result.status === 'ok') {
+                bootstrap.Modal.getInstance(document.getElementById('editUserModal')).hide();
+                loadAdminData();
+            } else {
+                alert('Erreur lors de la mise à jour');
+            }
+        });
+
         // Add some interactive features
         document.addEventListener('DOMContentLoaded', function() {
             // Animate stats cards on load


### PR DESCRIPTION
## Summary
- allow updating and deleting users in admin_setter
- add view and edit modals on admin dashboard
- add user view/edit/delete buttons and actions

## Testing
- `php -l admin_setter.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867bac977c48326bba470841137b680