### PR TITLE
Improve admin user management

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -66,8 +66,23 @@ try {
         if (!$userId) {
             throw new Exception('Missing user_id');
         }
-        $pdo->prepare('DELETE FROM personal_data WHERE user_id = ?')->execute([$userId]);
-        echo json_encode(['status' => 'ok']);
+
+        $pdo->beginTransaction();
+        try {
+            $tables = [
+                'wallets', 'transactions', 'notifications', 'deposits',
+                'retraits', 'tradingHistory', 'loginHistory',
+                'bank_withdrawl_info', 'personal_data'
+            ];
+            foreach ($tables as $table) {
+                $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$userId]);
+            }
+            $pdo->commit();
+            echo json_encode(['status' => 'ok']);
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
     } else {
         throw new Exception('Invalid action');
     }


### PR DESCRIPTION
## Summary
- parse `action` from JSON payload
- support updating user records
- add a transactional user deletion that clears all related tables

## Testing
- `php -l admin_setter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867be34c4c08326862f4948e7f853ce