### PR TITLE
Add user admin modals

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -627,6 +627,69 @@
         </div>
     </div>
     
+    <!-- View User Modal -->
+    <div class="modal fade" id="viewUserModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Détails Utilisateur</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Nom:</strong> <span id="viewFullName"></span></p>
+                    <p><strong>Email:</strong> <span id="viewEmail"></span></p>
+                    <p><strong>Date d'inscription:</strong> <span id="viewCreated"></span></p>
+                    <div class="progress mb-3">
+                        <div class="progress-bar" id="viewKycBar" role="progressbar" style="width:0%">0%</div>
+                    </div>
+                    <h6 class="mt-3">Dépôts récents</h6>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr><th>Date</th><th>Montant</th><th>Méthode</th><th>Statut</th></tr>
+                        </thead>
+                        <tbody id="viewDeposits"></tbody>
+                    </table>
+                    <h6 class="mt-3">Retraits récents</h6>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr><th>Date</th><th>Montant</th><th>Méthode</th><th>Statut</th></tr>
+                        </thead>
+                        <tbody id="viewWithdrawals"></tbody>
+                    </table>
+                    <h6 class="mt-3">Historique de Trading</h6>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr><th>Temps</th><th>Paire</th><th>Type</th><th>Montant</th><th>Prix</th><th>Statut</th><th>Profit/Perte</th></tr>
+                        </thead>
+                        <tbody id="viewTrading"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit User Modal -->
+    <div class="modal fade" id="editUserModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Modifier Utilisateur</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="editUserForm">
+                        <input type="hidden" id="editUserId">
+                        <div id="editUserFields" class="row g-3"></div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="button" class="btn btn-primary" id="saveEditUser">Enregistrer</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- KYC Details Modal -->
     <div class="modal fade" id="kycModal" tabindex="-1">
         <div class="modal-dialog modal-lg">
@@ -665,51 +728,6 @@
         </div>
     </div>
 
-    <!-- View User Modal -->
-    <div class="modal fade" id="viewUserModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Détails Utilisateur</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <p><strong>Nom:</strong> <span id="viewFullName"></span></p>
-                    <p><strong>Email:</strong> <span id="viewEmail"></span></p>
-                    <p><strong>Date d'inscription:</strong> <span id="viewCreated"></span></p>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Edit User Modal -->
-    <div class="modal fade" id="editUserModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Modifier Utilisateur</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="editUserForm">
-                        <input type="hidden" id="editUserId">
-                        <div class="mb-3">
-                            <label for="editFullName" class="form-label">Nom complet</label>
-                            <input type="text" class="form-control" id="editFullName" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="editEmail" class="form-label">Email</label>
-                            <input type="email" class="form-control" id="editEmail" required>
-                        </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                    <button type="button" class="btn btn-primary" id="saveEditUser">Enregistrer</button>
-                </div>
-            </div>
-        </div>
-    </div>
     
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
@@ -940,6 +958,36 @@
                 document.getElementById('viewFullName').textContent = pd.fullName || '';
                 document.getElementById('viewEmail').textContent = pd.emailaddress || '';
                 document.getElementById('viewCreated').textContent = pd.created_at || '';
+                const kyc = data.defaultKYCStatus || {};
+                let completed = 0, inProg = false;
+                Object.keys(kyc).forEach(k => {
+                    const v = typeof kyc[k] === 'object' ? String(kyc[k].status) : String(kyc[k]);
+                    if (v === '1') completed++; else if (v === '2') inProg = true;
+                });
+                const pct = Math.round((completed / Object.keys(kyc).length) * 100);
+                const bar = document.getElementById('viewKycBar');
+                bar.style.width = pct + '%';
+                bar.textContent = pct + '%';
+                bar.classList.remove('bg-success','bg-warning','bg-danger');
+                bar.classList.add(pct===100?'bg-success':inProg?'bg-warning':'bg-danger');
+                const depBody = document.getElementById('viewDeposits');
+                depBody.innerHTML = '';
+                (data.deposits || []).slice(0,10).forEach(d => {
+                    depBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(d.date)}</td><td>${escapeHtml(d.amount)}</td><td>${escapeHtml(d.method)}</td><td><span class="badge ${escapeHtml(d.statusClass)}">${escapeHtml(d.status)}</span></td></tr>`);
+                });
+                if (!depBody.innerHTML) depBody.innerHTML = '<tr><td colspan="4" class="text-center">Aucune donnée</td></tr>';
+                const witBody = document.getElementById('viewWithdrawals');
+                witBody.innerHTML = '';
+                (data.retraits || []).slice(0,10).forEach(r => {
+                    witBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(r.date)}</td><td>${escapeHtml(r.amount)}</td><td>${escapeHtml(r.method)}</td><td><span class="badge ${escapeHtml(r.statusClass)}">${escapeHtml(r.status)}</span></td></tr>`);
+                });
+                if (!witBody.innerHTML) witBody.innerHTML = '<tr><td colspan="4" class="text-center">Aucune donnée</td></tr>';
+                const tradeBody = document.getElementById('viewTrading');
+                tradeBody.innerHTML = '';
+                (data.tradingHistory || []).slice(0,10).forEach(t => {
+                    tradeBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(t.temps)}</td><td>${escapeHtml(t.paireDevises)}</td><td><span class="badge ${escapeHtml(t.statutTypeClass)}">${escapeHtml(t.type)}</span></td><td>${escapeHtml(t.montant)}</td><td>${escapeHtml(t.prix)}</td><td><span class="badge ${escapeHtml(t.statutClass)}">${escapeHtml(t.statut)}</span></td><td class="${escapeHtml(t.profitClass || '')}">${escapeHtml(t.profitPerte)}</td></tr>`);
+                });
+                if (!tradeBody.innerHTML) tradeBody.innerHTML = '<tr><td colspan="7" class="text-center">Aucune donnée</td></tr>';
                 new bootstrap.Modal(document.getElementById('viewUserModal')).show();
             } else if (editBtn) {
                 const id = editBtn.getAttribute('data-id');
@@ -947,8 +995,13 @@
                 const data = await res.json();
                 const pd = data.personalData || {};
                 document.getElementById('editUserId').value = id;
-                document.getElementById('editFullName').value = pd.fullName || '';
-                document.getElementById('editEmail').value = pd.emailaddress || '';
+                const container = document.getElementById('editUserFields');
+                container.innerHTML = '';
+                Object.keys(pd).forEach(key => {
+                    if (key === 'user_id') return;
+                    const val = pd[key] == null ? '' : pd[key];
+                    container.insertAdjacentHTML('beforeend', `<div class="col-md-6"><label class="form-label" for="edit_${escapeHtml(key)}">${escapeHtml(key)}</label><input type="text" class="form-control" id="edit_${escapeHtml(key)}" name="${escapeHtml(key)}" value="${escapeHtml(val)}"></div>`);
+                });
                 new bootstrap.Modal(document.getElementById('editUserModal')).show();
             } else if (delBtn) {
                 const id = delBtn.getAttribute('data-id');
@@ -965,12 +1018,14 @@
 
         document.getElementById('saveEditUser').addEventListener('click', async function() {
             const id = document.getElementById('editUserId').value;
-            const fullName = document.getElementById('editFullName').value.trim();
-            const email = document.getElementById('editEmail').value.trim();
+            const form = document.getElementById('editUserForm');
+            const inputs = form.querySelectorAll('[name]');
+            const user = { user_id: id };
+            inputs.forEach(i => { user[i.name] = i.value; });
             const res = await fetch('admin_setter.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ action: 'update_user', user: { user_id: id, fullName: fullName, emailaddress: email } })
+                body: JSON.stringify({ action: 'update_user', user: user })
             });
             const result = await res.json();
             if (result.status === 'ok') {


### PR DESCRIPTION
## Summary
- implement complete Edit User and View User modals in admin dashboard
- dynamically load personal data for editing and viewing
- display recent deposits, withdrawals, and trading history
- compute and show verification progress

## Testing
- `php -l admin_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867bf68b72c832694487c6677ea51f3