### PR TITLE
Add KYC progress indicator

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -642,6 +642,7 @@
                     <div class="progress mb-3">
                         <div class="progress-bar" id="viewKycBar" role="progressbar" style="width:0%">0%</div>
                     </div>
+                    <p><strong>KYC Status:</strong> <span id="viewKycLabel">pending</span></p>
                     <h6 class="mt-3">Dépôts récents</h6>
                     <table class="table table-sm">
                         <thead>
@@ -958,18 +959,15 @@
                 document.getElementById('viewFullName').textContent = pd.fullName || '';
                 document.getElementById('viewEmail').textContent = pd.emailaddress || '';
                 document.getElementById('viewCreated').textContent = pd.created_at || '';
-                const kyc = data.defaultKYCStatus || {};
-                let completed = 0, inProg = false;
-                Object.keys(kyc).forEach(k => {
-                    const v = typeof kyc[k] === 'object' ? String(kyc[k].status) : String(kyc[k]);
-                    if (v === '1') completed++; else if (v === '2') inProg = true;
-                });
-                const pct = Math.round((completed / Object.keys(kyc).length) * 100);
+                const steps = Object.values(data.defaultKYCStatus || {});
+                const completed = steps.filter(s => String(s.status) === '1').length;
+                const pct = Math.round((completed / steps.length) * 100);
                 const bar = document.getElementById('viewKycBar');
                 bar.style.width = pct + '%';
                 bar.textContent = pct + '%';
-                bar.classList.remove('bg-success','bg-warning','bg-danger');
-                bar.classList.add(pct===100?'bg-success':inProg?'bg-warning':'bg-danger');
+                bar.classList.remove('bg-success','bg-warning');
+                bar.classList.add(pct === 100 ? 'bg-success' : 'bg-warning');
+                document.getElementById('viewKycLabel').textContent = pct === 100 ? 'completed' : 'pending';
                 const depBody = document.getElementById('viewDeposits');
                 depBody.innerHTML = '';
                 (data.deposits || []).slice(0,10).forEach(d => {

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1289,6 +1289,7 @@
 <div class="progress mb-4">
 <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="30" class="progress-bar bg-warning" id="kycProgressBar" role="progressbar" style="width: 30%">30%</div>
 </div>
+<p><strong>KYC Status:</strong> <span id="kycStatusLabel">pending</span></p>
 <ul class="list-group mb-4">
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>

--- a/script.js
+++ b/script.js
@@ -98,6 +98,18 @@ async function fetchDashboardData() {
         const res = await fetch('getter.php?user_id=' + encodeURIComponent(userId));
         dashboardData = await res.json();
         console.log("Fetched dashboard data", dashboardData);
+        const steps = Object.values(dashboardData.defaultKYCStatus || {});
+        const completed = steps.filter(s => String(s.status) === '1').length;
+        const progress = Math.round((completed / steps.length) * 100);
+        dashboardData.kycProgress = progress;
+        const $bar = $('#kycProgressBar');
+        const $label = $('#kycStatusLabel');
+        if ($bar.length) {
+            $bar.css('width', progress + '%').text(progress + '%');
+        }
+        if ($label.length) {
+            $label.text(progress === 100 ? 'completed' : 'pending');
+        }
         updatePlatformBankDetails();
         initializeUI();
     } catch (err) {
@@ -140,31 +152,31 @@ function initializeUI() {
     }
 
     function updateKYCProgress() {
-        let completedSteps = 0;
-        let hasInProgress = false;
-        const keys = Object.keys(dashboardData.defaultKYCStatus);
-        keys.forEach(k => {
-            const valObj = dashboardData.defaultKYCStatus[k];
+        const steps = Object.values(dashboardData.defaultKYCStatus);
+        const completed = steps.filter(s => String(s.status) === '1').length;
+        let hasInProgress = steps.some(s => String(s.status) === '2');
+        steps.forEach((valObj, idx) => {
+            const key = Object.keys(dashboardData.defaultKYCStatus)[idx];
             const val = typeof valObj === 'object' ? String(valObj.status) : String(valObj);
-            const $badge = $('#' + k);
-            const $icon = $('#' + k.replace('stat', 'icon'));
+            const $badge = $('#' + key);
+            const $icon = $('#' + key.replace('stat', 'icon'));
             if (val === "1") {
                 $badge.text('complet').removeClass('bg-danger bg-warning bg-secondary').addClass('bg-success');
                 $icon.removeClass('fa-times-circle text-danger fa-clock text-warning').addClass('fa-check-circle text-success');
-                completedSteps++;
             } else if (val === "2") {
                 $badge.text('En cours').removeClass('bg-success bg-danger bg-secondary').addClass('bg-warning');
                 $icon.removeClass('fa-times-circle text-danger fa-check-circle text-success').addClass('fa-clock text-warning');
-                hasInProgress = true;
             } else {
                 $badge.text('Incomplet').removeClass('bg-success bg-warning bg-secondary').addClass('bg-danger');
                 $icon.removeClass('fa-check-circle text-success fa-clock text-warning').addClass('fa-times-circle text-danger');
             }
         });
-        const progress = (completedSteps / keys.length) * 100;
+        const progress = Math.round((completed / steps.length) * 100);
         const $bar = $('#kycProgressBar');
+        const $label = $('#kycStatusLabel');
         $bar.css('width', progress + '%').text(progress + '%').attr('aria-valuenow', progress);
         $bar.removeClass('bg-success bg-warning bg-danger');
+        if ($label.length) $label.text(progress === 100 ? 'completed' : 'pending');
         const $statusAlert = $('#alertWarning2');
         const $statusIcon = $('#alertWarning2 i');
         const $statusTitle = $('#alertWarning2 .alert-heading');


### PR DESCRIPTION
## Summary
- compute progress percentage after loading user data
- show updated KYC progress and status label in user dashboard
- display progress and status when viewing users in admin page

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6867c0f93c0c8326b69814e477f0d980