### PR TITLE
Add unique constraint to admin emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ field referencing the admin who created the record. The `personal_data` table
 now includes a `linked_to_id` column storing the `admins_agents.id` of the
 creator. When inserting or updating these records via `admin_setter.php`, make
 sure the password you send is already hashed using PHP's `password_hash()`.
+Each `email` in `admins_agents` must be unique, enforced by a `UNIQUE(email)`
+constraint in the schema.
 
 ## Wallet management
 

--- a/createtable.sql
+++ b/createtable.sql
@@ -64,5 +64,6 @@ CREATE TABLE admins_agents (
     email TEXT NOT NULL,
     password TEXT NOT NULL,
     is_admin TINYINT(1) NOT NULL,
-    created_by INTEGER NULL
+    created_by INTEGER NULL,
+    UNIQUE(email)
 );


### PR DESCRIPTION
## Summary
- enforce unique email addresses for admins and agents
- mention new `UNIQUE(email)` constraint in the docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867df4a79fc8326a645cea3d038aedd