### PR TITLE
Remove default admin fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ data.
 ## Admin dashboard
 
 `insertdata.sql` seeds a default administrator account (`admin@example.com`) with
-ID `1`. Opening `dashboard_admin.html` will automatically display this admin's
-data. `admin_getter.php` now defaults to ID `1` when no `admin_id` parameter is
-supplied, so you can browse the admin interface without logging in. Use the
-"Créer Agent" form to add new agents under the default admin.
+ID `1`. To load data for this account you now must be authenticated. The
+`admin_getter.php` endpoint looks for a session variable named `admin_id` or an
+`Authorization: Bearer <id>` header identifying the admin. If neither is
+present, the request is rejected with `401 Unauthorized`. Once authenticated,
+`dashboard_admin.html` will display the admin's agents and associated users.
+Use the "Créer Agent" form to add new agents under the logged‑in admin.
 

--- a/admin_getter.php
+++ b/admin_getter.php
@@ -3,7 +3,21 @@ $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
 $pdo = new PDO($dsn, 'root', '');
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$adminId = isset($_GET['admin_id']) ? (int)$_GET['admin_id'] : 1; // default admin
+$adminId = null;
+
+session_start();
+if (isset($_SESSION['admin_id'])) {
+    $adminId = (int)$_SESSION['admin_id'];
+} elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
+          preg_match('/Bearer\s+(\d+)/i', $_SERVER['HTTP_AUTHORIZATION'], $m)) {
+    $adminId = (int)$m[1];
+}
+
+if (!$adminId) {
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Unauthorized']);
+    exit;
+}
 
 $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
 $stmt->execute([$adminId]);


### PR DESCRIPTION
## Summary
- require authenticated admin for `admin_getter.php`
- document new authentication requirement for the admin dashboard

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e1fd761c8326b2ab32b5ecbf3996