### PR TITLE
Add admin statistics to dashboard

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -42,5 +42,29 @@ $stmt = $pdo->prepare('SELECT * FROM personal_data WHERE linked_to_id = ?');
 $stmt->execute([$adminId]);
 $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+// Compute statistics for the admin's users
+$userIds = array_column($result['users'], 'user_id');
+$totalUsers = count($userIds);
+$sumDeposits = 0;
+$successUsers = [];
+if ($userIds) {
+    $placeholders = implode(',', array_fill(0, count($userIds), '?'));
+    $sql = "SELECT user_id, amount FROM deposits WHERE status='complet' AND user_id IN ($placeholders)";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($userIds);
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $amount = preg_replace('/[^0-9.,-]/', '', $row['amount']);
+        $amount = str_replace(',', '', $amount);
+        $sumDeposits += (float)$amount;
+        $successUsers[$row['user_id']] = true;
+    }
+}
+$successRate = $totalUsers ? round(count($successUsers) / $totalUsers * 100, 2) : 0;
+$result['stats'] = [
+    'total_users' => $totalUsers,
+    'total_deposits' => $sumDeposits,
+    'success_rate' => $successRate,
+];
+
 header('Content-Type: application/json');
 echo json_encode($result);

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -142,7 +142,7 @@
                                 <div class="card stats-card">
                                     <div class="card-body text-center">
                                         <i class="bi bi-people fs-1 mb-2"></i>
-                                        <h3 class="mb-1">1,247</h3>
+                                        <h3 id="statTotalUsers" class="mb-1"></h3>
                                         <p class="mb-0">Utilisateurs Total</p>
                                     </div>
                                 </div>
@@ -151,8 +151,8 @@
                                 <div class="card stats-card">
                                     <div class="card-body text-center">
                                         <i class="bi bi-credit-card fs-1 mb-2"></i>
-                                        <h3 class="mb-1">€45,892</h3>
-                                        <p class="mb-0">Transactions Aujourd'hui</p>
+                                        <h3 id="statTotalDeposits" class="mb-1"></h3>
+                                        <p class="mb-0">Total Dépôts</p>
                                     </div>
                                 </div>
                             </div>
@@ -169,7 +169,7 @@
                                 <div class="card stats-card">
                                     <div class="card-body text-center">
                                         <i class="bi bi-check-circle fs-1 mb-2"></i>
-                                        <h3 class="mb-1">98.5%</h3>
+                                        <h3 id="statSuccessRate" class="mb-1"></h3>
                                         <p class="mb-0">Taux de Réussite</p>
                                     </div>
                                 </div>
@@ -828,6 +828,14 @@
                 const res = await fetch('admin_getter.php?admin_id=' + ADMIN_ID);
                 const data = await res.json();
                 IS_ADMIN = parseInt(data.is_admin || 0);
+
+                if (data.stats) {
+                    document.getElementById('statTotalUsers').textContent = data.stats.total_users;
+                    document.getElementById('statTotalDeposits').textContent =
+                        Number(data.stats.total_deposits).toLocaleString('en-US', {minimumFractionDigits: 2}) + ' $';
+                    document.getElementById('statSuccessRate').textContent =
+                        (data.stats.success_rate || 0) + '%';
+                }
 
                 document.getElementById('agentsNavItem').style.display = IS_ADMIN ? 'block' : 'none';
                 const quickBtn = document.getElementById('createAgentQuickBtn');


### PR DESCRIPTION
## Summary
- compute per-admin deposit stats in `admin_getter.php`
- hook up dashboard cards for total users, deposits and success rate
- populate new stats via `loadAdminData()` in `dashboard_admin.html`

## Testing
- `php -l admin_getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ec3030588326a6e9e2cb935b0878