### PR TITLE
Add admin login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ present, the request is rejected with `401 Unauthorized`. Once authenticated,
 `dashboard_admin.html` will display the admin's agents and associated users.
 Use the "Créer Agent" form to add new agents under the logged‑in admin.
 
+Use `admin_login.php` to sign in. POST `email` and `password`; a successful login starts a session and stores `admin_id` for subsequent requests.

--- a/admin_login.php
+++ b/admin_login.php
@@ -1,0 +1,30 @@
+<?php
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+header('Content-Type: application/json');
+
+$email = $_POST['email'] ?? '';
+$password = $_POST['password'] ?? '';
+
+if (!$email || !$password) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Missing credentials']);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT id, password FROM admins_agents WHERE email = ? LIMIT 1');
+$stmt->execute([$email]);
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($row && password_verify($password, $row['password'])) {
+    session_start();
+    $_SESSION['admin_id'] = $row['id'];
+    echo json_encode(['status' => 'ok']);
+    exit;
+}
+
+http_response_code(401);
+echo json_encode(['status' => 'error', 'message' => 'Invalid email or password']);
+


### PR DESCRIPTION
## Summary
- create `admin_login.php` to authenticate admins and start a session
- document the login flow in README

## Testing
- `php -l admin_login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686976abfc648326afb4d8f5e4e31917