### PR TITLE
Use admin ID for authorized requests

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -829,9 +829,15 @@
         let ADMIN_ID = null;
         let IS_ADMIN = 0;
 
+        function fetchWithAuth(url, options = {}) {
+            options.headers = options.headers || {};
+            if (ADMIN_ID) options.headers['Authorization'] = 'Bearer ' + ADMIN_ID;
+            return fetch(url, options);
+        }
+
         async function checkAuth() {
             try {
-                const res = await fetch('admin_getter.php');
+                const res = await fetchWithAuth('admin_getter.php');
                 if (!res.ok) throw new Error('unauthorized');
                 const data = await res.json();
                 if (data.admin_id) ADMIN_ID = data.admin_id;
@@ -868,7 +874,7 @@
 
         async function loadAdminData() {
             try {
-                const res = await fetch('admin_getter.php');
+                const res = await fetchWithAuth('admin_getter.php');
                 const data = await res.json();
                 if (data.admin_id) ADMIN_ID = data.admin_id;
                 IS_ADMIN = parseInt(data.is_admin || 0);
@@ -980,7 +986,7 @@
             }
 
             try {
-                const res = await fetch('admin_setter.php', {
+                const res = await fetchWithAuth('admin_setter.php', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload)
@@ -1019,7 +1025,7 @@
                 created_by: ADMIN_ID
             };
             try {
-                const res = await fetch('admin_setter.php', {
+                const res = await fetchWithAuth('admin_setter.php', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload)
@@ -1047,7 +1053,7 @@
             const delBtn = e.target.closest('.user-delete');
             if (viewBtn) {
                 const id = viewBtn.getAttribute('data-id');
-                const res = await fetch('getter.php?user_id=' + id);
+                const res = await fetchWithAuth('getter.php?user_id=' + id);
                 const data = await res.json();
                 const pd = data.personalData || {};
                 document.getElementById('viewFullName').textContent = pd.fullName || '';
@@ -1083,7 +1089,7 @@
                 new bootstrap.Modal(document.getElementById('viewUserModal')).show();
             } else if (editBtn) {
                 const id = editBtn.getAttribute('data-id');
-                const res = await fetch('getter.php?user_id=' + id);
+                const res = await fetchWithAuth('getter.php?user_id=' + id);
                 const data = await res.json();
                 const pd = data.personalData || {};
                 document.getElementById('editUserId').value = id;
@@ -1098,7 +1104,7 @@
             } else if (delBtn) {
                 const id = delBtn.getAttribute('data-id');
                 if (confirm('Supprimer cet utilisateur ?')) {
-                    await fetch('admin_setter.php', {
+                    await fetchWithAuth('admin_setter.php', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ action: 'delete_user', user_id: id })
@@ -1114,7 +1120,7 @@
             const inputs = form.querySelectorAll('[name]');
             const user = { user_id: id };
             inputs.forEach(i => { user[i.name] = i.value; });
-            const res = await fetch('admin_setter.php', {
+            const res = await fetchWithAuth('admin_setter.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'update_user', user: user })
@@ -1145,7 +1151,7 @@
                 } else if (delBtn) {
                     const id = delBtn.getAttribute('data-id');
                     if (confirm('Supprimer cet agent ?')) {
-                        await fetch('admin_setter.php', {
+                        await fetchWithAuth('admin_setter.php', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ action: 'delete_admin', id: id })
@@ -1161,7 +1167,7 @@
             const email = document.getElementById('editAgentEmail').value.trim();
             const role = document.getElementById('editAgentRole').value;
             const payload = { action: 'update_admin', id: id, email: email, is_admin: parseInt(role) };
-            const res = await fetch('admin_setter.php', {
+            const res = await fetchWithAuth('admin_setter.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- add a helper to send Authorization headers based on the logged in admin ID
- update admin dashboard fetch calls to include the auth header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68697d72e19c8326ae781c94204ac037