### PR TITLE
Update admin password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ contains an email, hashed password and an `is_admin` flag, plus a `created_by`
 field referencing the admin who created the record. The `personal_data` table
 now includes a `linked_to_id` column storing the `admins_agents.id` of the
 creator. When inserting or updating these records via `admin_setter.php`, make
-sure the password you send is already hashed using PHP's `password_hash()`.
+sure the password you send is pre-hashed on the client using the provided MD5
+algorithm.
 Each `email` in `admins_agents` must be unique, enforced by a `UNIQUE(email)`
 constraint in the schema.
 

--- a/admin_login.php
+++ b/admin_login.php
@@ -18,7 +18,8 @@ $stmt = $pdo->prepare('SELECT id, password FROM admins_agents WHERE email = ? LI
 $stmt->execute([$email]);
 $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-if ($row && password_verify($password, $row['password'])) {
+// Passwords are stored as MD5 hashes. The client sends the already hashed value.
+if ($row && hash_equals($row['password'], $password)) {
     session_start();
     $_SESSION['admin_id'] = $row['id'];
     echo json_encode(['status' => 'ok', 'admin_id' => $row['id']]);

--- a/admin_setter.php
+++ b/admin_setter.php
@@ -32,9 +32,9 @@ try {
         if (!$email || !$password) {
             throw new Exception('Missing parameters');
         }
-        $hash = password_hash($password, PASSWORD_DEFAULT);
+        // Passwords are now pre-hashed on the client using MD5
         $stmt = $pdo->prepare('INSERT INTO admins_agents (email, password, is_admin, created_by) VALUES (?,?,?,?)');
-        $stmt->execute([$email, $hash, $isAdmin, $createdBy]);
+        $stmt->execute([$email, $password, $isAdmin, $createdBy]);
         echo json_encode(['status' => 'ok', 'id' => $pdo->lastInsertId()]);
     } elseif ($action === 'create_user') {
         $user = $data['user'] ?? [];
@@ -43,7 +43,8 @@ try {
         }
         $password = $user['password'];
         unset($user['password']);
-        $user['passwordHash'] = password_hash($password, PASSWORD_DEFAULT);
+        // Client provides an MD5 hash for the password
+        $user['passwordHash'] = $password;
         if (!isset($user['created_at']) || $user['created_at'] === '') {
             $user['created_at'] = date('Y-m-d');
         }
@@ -87,7 +88,8 @@ try {
         }
         if (isset($data['password']) && $data['password'] !== '') {
             $fields[] = 'password = ?';
-            $values[] = password_hash($data['password'], PASSWORD_DEFAULT);
+            // Password is expected to be pre-hashed with MD5
+            $values[] = $data['password'];
         }
         if (isset($data['is_admin'])) {
             $fields[] = 'is_admin = ?';

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -829,6 +829,140 @@
         let ADMIN_ID = null;
         let IS_ADMIN = 0;
 
+        // Minimal MD5 implementation used to hash passwords client-side
+        function md5(str) {
+            function cmn(q, a, b, x, s, t) {
+                a = (a + q + x + t) | 0;
+                return (((a << s) | (a >>> (32 - s))) + b) | 0;
+            }
+            function ff(a, b, c, d, x, s, t) { return cmn((b & c) | (~b & d), a, b, x, s, t); }
+            function gg(a, b, c, d, x, s, t) { return cmn((b & d) | (c & ~d), a, b, x, s, t); }
+            function hh(a, b, c, d, x, s, t) { return cmn(b ^ c ^ d, a, b, x, s, t); }
+            function ii(a, b, c, d, x, s, t) { return cmn(c ^ (b | ~d), a, b, x, s, t); }
+
+            function md5cycle(x, k) {
+                let a = x[0], b = x[1], c = x[2], d = x[3];
+                a = ff(a, b, c, d, k[0], 7 , -680876936);
+                d = ff(d, a, b, c, k[1], 12, -389564586);
+                c = ff(c, d, a, b, k[2], 17,  606105819);
+                b = ff(b, c, d, a, k[3], 22, -1044525330);
+                a = ff(a, b, c, d, k[4], 7 , -176418897);
+                d = ff(d, a, b, c, k[5], 12,  1200080426);
+                c = ff(c, d, a, b, k[6], 17, -1473231341);
+                b = ff(b, c, d, a, k[7], 22, -45705983);
+                a = ff(a, b, c, d, k[8], 7 ,  1770035416);
+                d = ff(d, a, b, c, k[9], 12, -1958414417);
+                c = ff(c, d, a, b, k[10],17, -42063);
+                b = ff(b, c, d, a, k[11],22, -1990404162);
+                a = ff(a, b, c, d, k[12],7 ,  1804603682);
+                d = ff(d, a, b, c, k[13],12, -40341101);
+                c = ff(c, d, a, b, k[14],17, -1502002290);
+                b = ff(b, c, d, a, k[15],22,  1236535329);
+
+                a = gg(a, b, c, d, k[1], 5 , -165796510);
+                d = gg(d, a, b, c, k[6], 9 , -1069501632);
+                c = gg(c, d, a, b, k[11],14,  643717713);
+                b = gg(b, c, d, a, k[0], 20, -373897302);
+                a = gg(a, b, c, d, k[5], 5 , -701558691);
+                d = gg(d, a, b, c, k[10],9 ,  38016083);
+                c = gg(c, d, a, b, k[15],14, -660478335);
+                b = gg(b, c, d, a, k[4], 20, -405537848);
+                a = gg(a, b, c, d, k[9], 5 ,  568446438);
+                d = gg(d, a, b, c, k[14],9 , -1019803690);
+                c = gg(c, d, a, b, k[3], 14, -187363961);
+                b = gg(b, c, d, a, k[8], 20,  1163531501);
+                a = gg(a, b, c, d, k[13],5 , -1444681467);
+                d = gg(d, a, b, c, k[2], 9 , -51403784);
+                c = gg(c, d, a, b, k[7], 14,  1735328473);
+                b = gg(b, c, d, a, k[12],20, -1926607734);
+
+                a = hh(a, b, c, d, k[5], 4 , -378558);
+                d = hh(d, a, b, c, k[8], 11, -2022574463);
+                c = hh(c, d, a, b, k[11],16,  1839030562);
+                b = hh(b, c, d, a, k[14],23, -35309556);
+                a = hh(a, b, c, d, k[1], 4 , -1530992060);
+                d = hh(d, a, b, c, k[4], 11,  1272893353);
+                c = hh(c, d, a, b, k[7], 16, -155497632);
+                b = hh(b, c, d, a, k[10],23, -1094730640);
+                a = hh(a, b, c, d, k[13],4 ,  681279174);
+                d = hh(d, a, b, c, k[0], 11, -358537222);
+                c = hh(c, d, a, b, k[3], 16, -722521979);
+                b = hh(b, c, d, a, k[6], 23,  76029189);
+                a = hh(a, b, c, d, k[9], 4 , -640364487);
+                d = hh(d, a, b, c, k[12],11, -421815835);
+                c = hh(c, d, a, b, k[15],16,  530742520);
+                b = hh(b, c, d, a, k[2], 23, -995338651);
+
+                a = ii(a, b, c, d, k[0], 6 , -198630844);
+                d = ii(d, a, b, c, k[7], 10,  1126891415);
+                c = ii(c, d, a, b, k[14],15, -1416354905);
+                b = ii(b, c, d, a, k[5], 21, -57434055);
+                a = ii(a, b, c, d, k[12],6 ,  1700485571);
+                d = ii(d, a, b, c, k[3], 10, -1894986606);
+                c = ii(c, d, a, b, k[10],15, -1051523);
+                b = ii(b, c, d, a, k[1], 21, -2054922799);
+                a = ii(a, b, c, d, k[8], 6 ,  1873313359);
+                d = ii(d, a, b, c, k[15],10, -30611744);
+                c = ii(c, d, a, b, k[6], 15, -1560198380);
+                b = ii(b, c, d, a, k[13],21,  1309151649);
+                a = ii(a, b, c, d, k[4], 6 , -145523070);
+                d = ii(d, a, b, c, k[11],10, -1120210379);
+                c = ii(c, d, a, b, k[2], 15,  718787259);
+                b = ii(b, c, d, a, k[9], 21, -343485551);
+
+                x[0] = (a + x[0]) | 0;
+                x[1] = (b + x[1]) | 0;
+                x[2] = (c + x[2]) | 0;
+                x[3] = (d + x[3]) | 0;
+            }
+
+            function md51(s) {
+                const txt = unescape(encodeURIComponent(s));
+                const n = txt.length;
+                const state = [1732584193, -271733879, -1732584194, 271733878];
+                for (let i = 64; i <= n; i += 64) {
+                    md5cycle(state, md5blk(txt.substring(i - 64, i)));
+                }
+                let tail = new Array(16).fill(0);
+                let i = 0;
+                for (; i < n % 64; i++) {
+                    tail[i >> 2] |= txt.charCodeAt(n - (n % 64) + i) << ((i % 4) << 3);
+                }
+                tail[i >> 2] |= 0x80 << ((i % 4) << 3);
+                if (i > 55) {
+                    md5cycle(state, tail);
+                    tail = new Array(16).fill(0);
+                }
+                tail[14] = n * 8;
+                md5cycle(state, tail);
+                return state;
+            }
+
+            function md5blk(s) {
+                const md5blks = [];
+                for (let i = 0; i < 64; i += 4) {
+                    md5blks[i >> 2] = s.charCodeAt(i) +
+                        (s.charCodeAt(i + 1) << 8) +
+                        (s.charCodeAt(i + 2) << 16) +
+                        (s.charCodeAt(i + 3) << 24);
+                }
+                return md5blks;
+            }
+
+            function rhex(n) {
+                let s = '';
+                for (let j = 0; j < 4; j++) {
+                    s += ((n >> (j * 8 + 4)) & 0x0f).toString(16) +
+                        ((n >> (j * 8)) & 0x0f).toString(16);
+                }
+                return s;
+            }
+
+            function hex(x) { return x.map(rhex).join(''); }
+
+            return hex(md51(str));
+        }
+
         function fetchWithAuth(url, options = {}) {
             options.headers = options.headers || {};
             if (ADMIN_ID) options.headers['Authorization'] = 'Bearer ' + ADMIN_ID;
@@ -852,7 +986,11 @@
 
         document.getElementById('adminLoginForm').addEventListener('submit', async function(e) {
             e.preventDefault();
-            const formData = new FormData(this);
+            const email = document.getElementById('loginEmail').value.trim();
+            const pwd = document.getElementById('loginPassword').value;
+            const formData = new FormData();
+            formData.append('email', email);
+            formData.append('password', md5(pwd));
             const res = await fetch('admin_login.php', { method: 'POST', body: formData });
             const result = await res.json();
             if (result.status === 'ok') {
@@ -971,7 +1109,7 @@
                         user_id: Date.now(),
                         fullName: firstName + ' ' + lastName,
                         emailaddress: email,
-                        password: password,
+                        password: md5(password),
                         linked_to_id: ADMIN_ID
                     }
                 };
@@ -979,7 +1117,7 @@
                 payload = {
                     action: 'create_admin',
                     email: email,
-                    password: password,
+                    password: md5(password),
                     is_admin: 1,
                     created_by: ADMIN_ID
                 };
@@ -1020,7 +1158,7 @@
             const payload = {
                 action: 'create_admin',
                 email: email,
-                password: pass,
+                password: md5(pass),
                 is_admin: isAdminVal,
                 created_by: ADMIN_ID
             };

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -1,5 +1,5 @@
 INSERT INTO admins_agents (email, password, is_admin, created_by)
-VALUES ('admin@example.com', '$2b$12$DujgN6sRcXHjyuXJkcTmgedBXpP9jwonqolpXmLOn2Z39RQS59EJa', 1, NULL);
+VALUES ('admin@example.com', '0192023a7bbd73250516f069df18b500', 1, NULL);
 
 INSERT INTO personal_data VALUES (
 1, '3,500 $', '1200 $', '800 $', '10', 


### PR DESCRIPTION
## Summary
- switch admin auth from bcrypt to MD5
- let admin_login.php compare MD5 hashes directly
- expect MD5 hashes in admin_setter.php
- hash admin/agent credentials client-side in dashboard_admin.html
- document new MD5 requirement
- adjust seed data for admin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869882e61688326ad45fc055069a7f5