### PR TITLE
Hide sensitive fields from admin edit form

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1252,8 +1252,9 @@
                 document.getElementById('editUserId').value = id;
                 const container = document.getElementById('editUserFields');
                 container.innerHTML = '';
+                const hiddenFields = ['compteverifie','compteverifie01','niveauavance','passwordStrength','passwordStrengthBar','passwordHash'];
                 Object.keys(pd).forEach(key => {
-                    if (key === 'user_id') return;
+                    if (key === 'user_id' || hiddenFields.includes(key)) return;
                     const val = pd[key] == null ? '' : pd[key];
                     container.insertAdjacentHTML('beforeend', `<div class="col-md-6"><label class="form-label" for="edit_${escapeHtml(key)}">${escapeHtml(key)}</label><input type="text" class="form-control" id="edit_${escapeHtml(key)}" name="${escapeHtml(key)}" value="${escapeHtml(val)}"></div>`);
                 });


### PR DESCRIPTION
## Summary
- hide backend-only user fields in the admin edit form by skipping them when building inputs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a683546c483269f5e021d1a86a523