### PR TITLE
Handle deposits and withdrawals in update_transaction

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -162,8 +162,18 @@ try {
         if (!$id) {
             throw new Exception('Missing id');
         }
+
+        $table = 'transactions';
+        if ($id >= 2000000) {
+            $id -= 2000000;
+            $table = 'retraits';
+        } elseif ($id >= 1000000) {
+            $id -= 1000000;
+            $table = 'deposits';
+        }
+
         if (!empty($data['delete'])) {
-            $stmt = $pdo->prepare('DELETE FROM transactions WHERE id = ?');
+            $stmt = $pdo->prepare("DELETE FROM $table WHERE id = ?");
             $stmt->execute([$id]);
             echo json_encode(['status' => 'ok']);
         } else {
@@ -172,7 +182,7 @@ try {
             if ($status === null || $class === null) {
                 throw new Exception('Missing status');
             }
-            $stmt = $pdo->prepare('UPDATE transactions SET status = ?, statusClass = ? WHERE id = ?');
+            $stmt = $pdo->prepare("UPDATE $table SET status = ?, statusClass = ? WHERE id = ?");
             $stmt->execute([$status, $class, $id]);
             echo json_encode(['status' => 'ok']);
         }


### PR DESCRIPTION
## Summary
- support editing or deleting deposit and withdrawal records
  in `admin_setter.php`'s `update_transaction` action

## Testing
- `php -l admin_setter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bebcc7de883268aa7096b025d355b