### PR TITLE
Normalize monetary fields

### DIFF
--- a/createtable.sql
+++ b/createtable.sql
@@ -1,9 +1,9 @@
 
 CREATE TABLE personal_data (
     user_id INTEGER PRIMARY KEY,
-    balance TEXT,
-    totalDepots TEXT,
-    totalRetraits TEXT,
+    balance DECIMAL(18,2),
+    totalDepots DECIMAL(18,2),
+    totalRetraits DECIMAL(18,2),
     nbTransactions TEXT,
     fullName TEXT,
     compteverifie TEXT,
@@ -44,11 +44,11 @@ CREATE TABLE wallets (
     label TEXT
 );
 
-CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, operationNumber TEXT, type TEXT, amount TEXT, date TEXT, status TEXT, statusClass TEXT);
+CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, operationNumber TEXT, type TEXT, amount DECIMAL(18,2), date TEXT, status TEXT, statusClass TEXT);
 CREATE TABLE notifications (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, type TEXT, title TEXT, message TEXT, time TEXT, alertClass TEXT);
-CREATE TABLE deposits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, amount TEXT, method TEXT, status TEXT, statusClass TEXT);
-CREATE TABLE retraits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, amount TEXT, method TEXT, status TEXT, statusClass TEXT);
-CREATE TABLE tradingHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, temps TEXT, paireDevises TEXT, type TEXT, statutTypeClass TEXT, montant TEXT, prix TEXT, statut TEXT, statutClass TEXT, profitPerte TEXT, profitClass TEXT);
+CREATE TABLE deposits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, amount DECIMAL(18,2), method TEXT, status TEXT, statusClass TEXT);
+CREATE TABLE retraits (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, amount DECIMAL(18,2), method TEXT, status TEXT, statusClass TEXT);
+CREATE TABLE tradingHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, temps TEXT, paireDevises TEXT, type TEXT, statutTypeClass TEXT, montant DECIMAL(18,2), prix DECIMAL(18,2), statut TEXT, statutClass TEXT, profitPerte DECIMAL(18,2), profitClass TEXT);
 CREATE TABLE loginHistory (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER, date TEXT, ip TEXT, device TEXT);
 CREATE TABLE bank_withdrawl_info (
     user_id INTEGER PRIMARY KEY,

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -2,7 +2,7 @@ INSERT INTO admins_agents (email, password, is_admin, created_by)
 VALUES ('admin@example.com', '0192023a7bbd73250516f069df18b500', 1, NULL);
 
 INSERT INTO personal_data VALUES (
-1, '3,500 $', '1200 $', '800 $', '10', 
+1, 3500, 1200, 800, '10',
 'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2', 
 'c1de8b176818ec85532879c60030aedd', 'Fort', '90%', 
 '0', '0', '0', '1', '0', 
@@ -19,28 +19,28 @@ INSERT INTO wallets VALUES (
     'BTC12345678', ''
 );
 
-INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12345', 'Dépôt', '$100', '06/01/2025', 'complet', 'bg-success');
-INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12344', 'Retrait', '$200', '05/28/2025', 'complet', 'bg-success');
-INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12343', 'Dépôt', '$300', '05/25/2025', 'complet', 'bg-success');
-INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12342', 'Retrait', '$150', '05/20/2025', 'En cours', 'bg-warning');
+INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12345', 'Dépôt', 100, '06/01/2025', 'complet', 'bg-success');
+INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12344', 'Retrait', 200, '05/28/2025', 'complet', 'bg-success');
+INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12343', 'Dépôt', 300, '05/25/2025', 'complet', 'bg-success');
+INSERT INTO transactions (user_id, operationNumber, type, amount, date, status, statusClass) VALUES (1, '#12342', 'Retrait', 150, '05/20/2025', 'En cours', 'bg-warning');
 INSERT INTO notifications (user_id, type, title, message, time, alertClass) VALUES (1, 'info', 'Mise à jour du système', 'Le système sera mis à jour vendredi prochain.', 'Il y a 2 heures', 'alert-info');
 INSERT INTO notifications (user_id, type, title, message, time, alertClass) VALUES (1, 'success', 'Dépôt réussi', 'Un montant de 500 $ a été déposé avec succès.', 'Il y a un jour', 'alert-success');
 INSERT INTO notifications (user_id, type, title, message, time, alertClass) VALUES (1, 'warning', 'Vérification KYC', 'Merci de vérifier votre identité.', 'Il y a 3 jours', 'alert-warning');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '150 $', 'Bitcoin', 'En cours', 'bg-warning');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '150 $', 'Carte', 'En cours', 'bg-warning');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '100 $', 'Banque', 'En cours', 'bg-warning');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/01', '$500', 'Carte', 'En cours', 'bg-warning');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/15', '$300', 'Banque', 'complet', 'bg-success');
-INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/02', '$400', 'Bitcoin', 'complet', 'bg-success');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '700 $', 'Paypal', 'En cours', 'bg-warning');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '200 $', 'Ethereum', 'En cours', 'bg-warning');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', '1,000 $', 'Banque', 'En cours', 'bg-warning');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/28', '$200', 'Banque', 'complet', 'bg-success');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/20', '$150', 'Bitcoin', 'En cours', 'bg-warning');
-INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/10', '$300', 'Paypal', 'complet', 'bg-success');
-INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 14:30', 'BTC/USD', 'Acheter', 'bg-success', '$1,000', '$500', 'complet', 'bg-success', '+$175.50', 'text-success');
-INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 13:15', 'ETH/USD', 'Vendre', 'bg-success', '$500', '$2,850', 'complet', 'bg-success', '-$25.00', 'text-danger');
-INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 12:00', 'ADA/USD', 'Acheter', 'bg-danger', '$300', '$0.45', 'En cours', 'bg-warning', '-', '');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 150, 'Bitcoin', 'En cours', 'bg-warning');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 150, 'Carte', 'En cours', 'bg-warning');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 100, 'Banque', 'En cours', 'bg-warning');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/01', 500, 'Carte', 'En cours', 'bg-warning');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/15', 300, 'Banque', 'complet', 'bg-success');
+INSERT INTO deposits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/02', 400, 'Bitcoin', 'complet', 'bg-success');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 700, 'Paypal', 'En cours', 'bg-warning');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 200, 'Ethereum', 'En cours', 'bg-warning');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/06/27', 1000, 'Banque', 'En cours', 'bg-warning');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/28', 200, 'Banque', 'complet', 'bg-success');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/20', 150, 'Bitcoin', 'En cours', 'bg-warning');
+INSERT INTO retraits (user_id, date, amount, method, status, statusClass) VALUES (1, '2025/05/10', 300, 'Paypal', 'complet', 'bg-success');
+INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 14:30', 'BTC/USD', 'Acheter', 'bg-success', 1000, 500, 'complet', 'bg-success', 175.50, 'text-success');
+INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 13:15', 'ETH/USD', 'Vendre', 'bg-success', 500, 2850, 'complet', 'bg-success', -25.00, 'text-danger');
+INSERT INTO tradingHistory (user_id, temps, paireDevises, type, statutTypeClass, montant, prix, statut, statutClass, profitPerte, profitClass) VALUES (1, '2025/06/09 12:00', 'ADA/USD', 'Acheter', 'bg-danger', 300, 0.45, 'En cours', 'bg-warning', NULL, '');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/09 15:00', '192.168.0.1', 'Chrome - Windows');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/08 18:20', '192.168.0.2', 'Firefox - Android');
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/07 09:10', '192.168.0.3', 'Safari - iOS');

--- a/script.js
+++ b/script.js
@@ -142,7 +142,7 @@ $(document).ready(async function () {
 function initializeUI() {
     dashboardData.personalData.wallets = dashboardData.wallets || dashboardData.personalData.wallets || [];
     function updateBalances() {
-        const bal = formatDollar(parseDollar(dashboardData.personalData.balance));
+        const bal = formatDollar(Number(dashboardData.personalData.balance));
         $('#soldeTotal').text(bal);
         $('#soldeintrade').text(bal);
         $('#soldedisponible1').text(bal);
@@ -396,7 +396,7 @@ function initializeUI() {
                     <tr>
                         <td>${escapeHtml(t.operationNumber)}</td>
                         <td>${escapeHtml(t.type)}</td>
-                        <td>${escapeHtml(t.amount)}</td>
+                        <td>${formatDollar(t.amount)}</td>
                         <td>${escapeHtml(t.date)}</td>
                         <td><span class="badge ${escapeHtml(t.statusClass)}">${escapeHtml(t.status)}</span></td>
                     </tr>`);
@@ -719,21 +719,21 @@ function initializeUI() {
             }[this.id];
             const amt = parseFloat($(amountField).val());
             if (!isNaN(amt) && amt > 0) {
-                const cur = parseDollar(dashboardData.personalData.balance);
-                dashboardData.personalData.balance = formatDollar(cur - amt);
+                const cur = Number(dashboardData.personalData.balance);
+                dashboardData.personalData.balance = cur - amt;
                 const method = this.id === 'bankWithdrawForm' ? 'Banque' :
                     this.id === 'paypalWithdrawForm' ? 'Paypal' :
                     (currencyNames[$('#cryptoCurrencyWithdraw').val()] || 'Crypto');
                 dashboardData.retraits = dashboardData.retraits || [];
                 dashboardData.retraits.unshift({
                     date: today,
-                    amount: formatDollar(amt),
+                    amount: amt,
                     method,
                     status: 'En cours',
                     statusClass: 'bg-warning'
                 });
                 dashboardData.retraits = dashboardData.retraits.slice(0, 10);
-                addTransactionRecord('Retrait', formatDollar(amt));
+                addTransactionRecord('Retrait', amt);
                 updateBalances();
                 renderWithdrawHistory();
                 renderRecentTransactions();
@@ -771,15 +771,15 @@ function initializeUI() {
             }[this.id];
             const amt = parseFloat($(amountField).val());
             if (!isNaN(amt) && amt > 0) {
-                const cur = parseDollar(dashboardData.personalData.balance);
-                dashboardData.personalData.balance = formatDollar(cur + amt);
+                const cur = Number(dashboardData.personalData.balance);
+                dashboardData.personalData.balance = cur + amt;
                 const method = this.id === 'bankDepositForm' ? 'Banque' :
                     this.id === 'cardDepositForm' ? 'Carte' :
                     (currencyNames[$('#cryptoCurrency').val()] || 'Crypto');
                 dashboardData.deposits = dashboardData.deposits || [];
                 dashboardData.deposits.unshift({
                     date: today,
-                    amount: formatDollar(amt),
+                    amount: amt,
                     method,
                     status: 'En cours',
                     statusClass: 'bg-warning'
@@ -787,7 +787,7 @@ function initializeUI() {
                 dashboardData.deposits = dashboardData.deposits.slice(0, 10);
                 renderDepositHistory();
                 updateBalances();
-                addTransactionRecord('Dépôt', formatDollar(amt));
+                addTransactionRecord('Dépôt', amt);
                 renderRecentTransactions();
                 showBootstrapAlert('depositAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
                 saveDashboardData();
@@ -1022,7 +1022,7 @@ function initializeUI() {
                 $tbodyDeposits.append(`
                     <tr>
                         <td>${escapeHtml(d.date)}</td>
-                        <td>${escapeHtml(d.amount)}</td>
+                        <td>${formatDollar(d.amount)}</td>
                         <td>${escapeHtml(d.method)}</td>
                         <td><span class="badge ${escapeHtml(d.statusClass)}">${escapeHtml(d.status)}</span></td>
                     </tr>`);
@@ -1041,7 +1041,7 @@ function initializeUI() {
                 $tbodyRetraits.append(`
                     <tr>
                         <td>${escapeHtml(r.date)}</td>
-                        <td>${escapeHtml(r.amount)}</td>
+                        <td>${formatDollar(r.amount)}</td>
                         <td>${escapeHtml(r.method)}</td>
                         <td><span class="badge ${escapeHtml(r.statusClass)}">${escapeHtml(r.status)}</span></td>
                     </tr>`);
@@ -1073,15 +1073,16 @@ function initializeUI() {
         $tbodyTrading.empty();
         if (dashboardData.tradingHistory?.length > 0) {
             dashboardData.tradingHistory.slice(0, 5).forEach(trade => {
+                const profit = trade.profitPerte == null ? '-' : (trade.profitPerte >= 0 ? '+' : '') + formatDollar(Math.abs(trade.profitPerte));
                 $tbodyTrading.append(`
                     <tr>
                         <td>${escapeHtml(trade.temps)}</td>
                         <td>${escapeHtml(trade.paireDevises)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutTypeClass)}">${escapeHtml(trade.type)}</span></td>
-                        <td>${escapeHtml(trade.montant)}</td>
-                        <td>${escapeHtml(trade.prix)}</td>
+                        <td>${formatDollar(trade.montant)}</td>
+                        <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
-                        <td class="${escapeHtml(trade.profitClass || '')}">${escapeHtml(trade.profitPerte)}</td>
+                        <td class="${escapeHtml(trade.profitClass || '')}">${profit}</td>
                     </tr>`);
             });
         } else {
@@ -1128,15 +1129,15 @@ function initializeUI() {
     }
 
     function finalizeOrder(order, exitPrice) {
-        const priceValue = parseFloat(order.prix.replace('$', ''));
-        const qty = parseFloat(order.montant.replace('$', ''));
+        const priceValue = Number(order.prix);
+        const qty = Number(order.montant);
         let profit = 0;
         if (order.type === 'Acheter') {
             profit = (exitPrice - priceValue) * qty;
         } else {
             profit = (priceValue - exitPrice) * qty;
         }
-        order.profitPerte = (profit >= 0 ? '+' : '') + profit.toFixed(2) + '$';
+        order.profitPerte = profit;
         order.profitClass = profit >= 0 ? 'text-success' : 'text-danger';
         order.statut = 'complet';
         order.statutClass = 'bg-success';
@@ -1154,9 +1155,9 @@ function initializeUI() {
             });
         }
         const invested = order.invested || priceValue * qty;
-        let balance = parseDollar(dashboardData.personalData.balance);
+        let balance = Number(dashboardData.personalData.balance);
         balance += invested + profit;
-        dashboardData.personalData.balance = formatDollar(balance);
+        dashboardData.personalData.balance = balance;
         saveDashboardData();
         updateBalances();
         renderTradingHistory();
@@ -1176,7 +1177,7 @@ function initializeUI() {
                 return;
             }
             const sl = order.stopLoss;
-            const entryPrice = parseFloat(order.prix.replace('$', ''));
+            const entryPrice = Number(order.prix);
             if (sl.type === 'price') {
                 if ((order.type === 'Acheter' && currentPrice <= sl.price) ||
                     (order.type === 'Vendre' && currentPrice >= sl.price)) {
@@ -1311,12 +1312,12 @@ function initializeUI() {
             }
         }
         const cost = amount * price;
-        if (cost > parseDollar(dashboardData.personalData.balance)) {
+        if (cost > Number(dashboardData.personalData.balance)) {
             alert('Solde insuffisant');
             return;
         }
-        let newBalance = parseDollar(dashboardData.personalData.balance) - cost;
-        dashboardData.personalData.balance = formatDollar(newBalance);
+        let newBalance = Number(dashboardData.personalData.balance) - cost;
+        dashboardData.personalData.balance = newBalance;
         saveDashboardData();
         updateBalances();
 
@@ -1351,11 +1352,11 @@ function initializeUI() {
             paireDevises: pair.replace('USD', '/USD'),
             type: isBuy ? 'Acheter' : 'Vendre',
             statutTypeClass: isBuy ? 'bg-success' : 'bg-danger',
-            montant: '$' + amount,
-            prix: '$' + price,
+            montant: amount,
+            prix: price,
             statut: 'En cours',
             statutClass: 'bg-warning',
-            profitPerte: '-',
+            profitPerte: null,
             profitClass: '',
             stopLoss: stopLoss,
             stopLimit: orderType === 'stoplimit' ? { stopPrice: stopPrice, limitPrice: price } : null,
@@ -1366,7 +1367,7 @@ function initializeUI() {
         };
 
         if (ocoEnabled) {
-            const tpOrder = Object.assign({}, order, { stopLoss: null, takeProfit: takeProfit, prix: '$' + takeProfit });
+            const tpOrder = Object.assign({}, order, { stopLoss: null, takeProfit: takeProfit, prix: takeProfit });
             const slOrder = Object.assign({}, order, { takeProfit: null });
             addTrade(tpOrder);
             addTrade(slOrder);

--- a/setter.php
+++ b/setter.php
@@ -22,6 +22,11 @@ try {
         $wallets = $personal['wallets'] ?? ($data['wallets'] ?? []);
         unset($personal['wallets']);
 
+        foreach ($numericFields['personal_data'] as $nf) {
+            if (isset($personal[$nf])) {
+                $personal[$nf] = (float)$personal[$nf];
+            }
+        }
         $cols = array_keys($personal);
         $place = implode(',', array_fill(0, count($cols), '?'));
         $sql = 'REPLACE INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ')';
@@ -54,6 +59,13 @@ try {
         'tradingHistory' => ['temps','paireDevises','type','statutTypeClass','montant','prix','statut','statutClass','profitPerte','profitClass'],
         'loginHistory' => ['date','ip','device'],
     ];
+    $numericFields = [
+        'personal_data' => ['balance','totalDepots','totalRetraits'],
+        'transactions' => ['amount'],
+        'deposits' => ['amount'],
+        'retraits' => ['amount'],
+        'tradingHistory' => ['montant','prix','profitPerte'],
+    ];
 
     foreach ($tables as $table => $cols) {
         $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$userId]);
@@ -64,7 +76,11 @@ try {
             foreach ($data[$table] as $row) {
                 $values = [$userId];
                 foreach ($cols as $c) {
-                    $values[] = $row[$c] ?? null;
+                    $v = $row[$c] ?? null;
+                    if (in_array($c, $numericFields[$table] ?? [])) {
+                        $v = $v !== null ? (float)$v : null;
+                    }
+                    $values[] = $v;
                 }
                 $stmt->execute($values);
             }


### PR DESCRIPTION
## Summary
- store monetary data using numeric SQL types
- sanitize insert scripts to drop currency symbols
- adjust setter to cast numeric fields
- keep amounts as numbers in the client and format only for display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bfd694ed48326a86b5d88410d6703