### PR TITLE
Adjust withdraw history columns

### DIFF
--- a/script.js
+++ b/script.js
@@ -1061,7 +1061,6 @@ function initializeUI() {
             dashboardData.retraits.slice(0, 10).forEach(r => {
                 $tbodyRetraits.append(`
                     <tr>
-                        <td>${escapeHtml(r.operationNumber)}</td>
                         <td>${escapeHtml(r.date)}</td>
                         <td>${formatDollar(r.amount)}</td>
                         <td>${escapeHtml(r.method)}</td>
@@ -1069,7 +1068,7 @@ function initializeUI() {
                     </tr>`);
             });
         } else {
-            $tbodyRetraits.html('<tr><td colspan="5" class="text-center">Aucune donnée disponible</td></tr>');
+            $tbodyRetraits.html('<tr><td colspan="4" class="text-center">Aucune donnée disponible</td></tr>');
         }
     }
 


### PR DESCRIPTION
## Summary
- keep withdrawal table in `dashbord_user.html` to 4 columns
- remove `operationNumber` cell in `renderWithdrawHistory()` and update empty message colspan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c0be89e1883269f3334093d8fd17f