### PR TITLE
Fix transaction query

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -18,26 +18,12 @@ if (!$adminId) {
     exit;
 }
 
-$sql = "(
-        SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
-        FROM transactions t
-        WHERE t.admin_id = ?
-    )
-    UNION ALL
-    (
-        SELECT d.operationNumber, d.user_id, 'Dépôt' AS type, d.amount, d.status, d.date, d.statusClass
-        FROM deposits d
-        WHERE d.admin_id = ?
-    )
-    UNION ALL
-    (
-        SELECT r.operationNumber, r.user_id, 'Retrait' AS type, r.amount, r.status, r.date, r.statusClass
-        FROM retraits r
-        WHERE r.admin_id = ?
-    )
-    ORDER BY STR_TO_DATE(date, '%Y/%m/%d') DESC";
+$sql = "SELECT operationNumber, user_id, type, amount, status, date, statusClass
+        FROM transactions
+        WHERE admin_id = ?
+        ORDER BY STR_TO_DATE(date, '%Y/%m/%d') DESC";
 $stmt = $pdo->prepare($sql);
-$stmt->execute([$adminId, $adminId, $adminId]);
+$stmt->execute([$adminId]);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- simplify transaction retrieval for admins

## Testing
- `php -l admin_transactions_getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2140980083269636bcd6d36500a5