### PR TITLE
Add deposit count to admin stats

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -48,6 +48,7 @@ $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $userIds = array_column($result['users'], 'user_id');
 $totalUsers = count($userIds);
 $sumDeposits = 0;
+$depositCount = 0;
 $successUsers = [];
 if ($userIds) {
     $placeholders = implode(',', array_fill(0, count($userIds), '?'));
@@ -56,6 +57,7 @@ if ($userIds) {
     $stmt->execute($userIds);
     foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
         $sumDeposits += (float)$row['amount'];
+        $depositCount++;
         $successUsers[$row['user_id']] = true;
     }
 }
@@ -63,6 +65,7 @@ $successRate = $totalUsers ? round(count($successUsers) / $totalUsers * 100, 2) 
 $result['stats'] = [
     'total_users' => $totalUsers,
     'total_deposits' => $sumDeposits,
+    'deposit_count' => $depositCount,
     'success_rate' => $successRate,
 ];
 

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -175,9 +175,9 @@
                             <div class="col-md-3 mb-3">
                                 <div class="card stats-card">
                                     <div class="card-body text-center">
-                                        <i class="bi bi-clock-history fs-1 mb-2"></i>
-                                        <h3 class="mb-1">23</h3>
-                                        <p class="mb-0">KYC en Attente</p>
+                                        <i class="bi bi-stack fs-1 mb-2"></i>
+                                        <h3 id="statDepositCount" class="mb-1"></h3>
+                                        <p class="mb-0">Nombre de dépôts</p>
                                     </div>
                                 </div>
                             </div>
@@ -1054,6 +1054,7 @@
                     document.getElementById('statTotalUsers').textContent = data.stats.total_users;
                     document.getElementById('statTotalDeposits').textContent =
                         Number(data.stats.total_deposits).toLocaleString('en-US', {minimumFractionDigits: 2}) + ' $';
+                    document.getElementById('statDepositCount').textContent = data.stats.deposit_count || 0;
                     document.getElementById('statSuccessRate').textContent =
                         (data.stats.success_rate || 0) + '%';
                 }


### PR DESCRIPTION
## Summary
- extend `admin_getter.php` to tally completed deposit records for the admin's users
- expose the deposit count in the `stats` object
- show the value in the admin dashboard

## Testing
- `php -l admin_getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2594d6048326b7cc710180e5b918