### PR TITLE
Add uniform PHP error logging

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -1,7 +1,13 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $adminId = null;
 
@@ -69,5 +75,9 @@ $result['stats'] = [
     'success_rate' => $successRate,
 ];
 
-header('Content-Type: application/json');
 echo json_encode($result);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/admin_login.php
+++ b/admin_login.php
@@ -1,9 +1,13 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
 header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $email = $_POST['email'] ?? '';
 $password = $_POST['password'] ?? '';
@@ -28,4 +32,8 @@ if ($row && hash_equals($row['password'], $password)) {
 
 http_response_code(401);
 echo json_encode(['status' => 'error', 'message' => 'Invalid email or password']);
-
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/admin_logout.php
+++ b/admin_logout.php
@@ -1,6 +1,16 @@
 <?php
-session_start();
-session_unset();
-session_destroy();
 header('Content-Type: application/json');
-echo json_encode(['status' => 'ok']);
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    session_start();
+    session_unset();
+    session_destroy();
+    echo json_encode(['status' => 'ok']);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/admin_setter.php
+++ b/admin_setter.php
@@ -1,10 +1,16 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
 
-$adminId = null;
-session_start();
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $adminId = null;
+    session_start();
 if (isset($_SESSION['admin_id'])) {
     $adminId = (int)$_SESSION['admin_id'];
 } elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
@@ -273,7 +279,8 @@ try {
     } else {
         throw new Exception('Invalid action');
     }
-} catch (Exception $e) {
-    http_response_code(400);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
     echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
 }

--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -1,10 +1,16 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
 
-$adminId = null;
-session_start();
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $adminId = null;
+    session_start();
 if (isset($_SESSION['admin_id'])) {
     $adminId = (int)$_SESSION['admin_id'];
 } elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
@@ -26,5 +32,9 @@ $stmt = $pdo->prepare($sql);
 $stmt->execute([$adminId]);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-header('Content-Type: application/json');
 echo json_encode(['transactions' => $rows]);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/get_wallets.php
+++ b/get_wallets.php
@@ -1,7 +1,13 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $input = file_get_contents('php://input');
@@ -36,7 +42,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->execute([$id, $userId]);
     }
 
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'ok']);
     exit;
 }
@@ -46,5 +51,9 @@ $stmt = $pdo->prepare('SELECT * FROM wallets WHERE user_id = ?');
 $stmt->execute([$userId]);
 $wallets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-header('Content-Type: application/json');
 echo json_encode(['wallets' => $wallets]);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/getter.php
+++ b/getter.php
@@ -1,9 +1,15 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
 
-$userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
 
 function fetchAll($pdo, $sql, $params = []) {
     $stmt = $pdo->prepare($sql);
@@ -37,5 +43,9 @@ $data = [
     ],
 ];
 
-header('Content-Type: application/json');
 echo json_encode($data);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/setter.php
+++ b/setter.php
@@ -1,19 +1,24 @@
 <?php
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-$input = file_get_contents('php://input');
-$data = json_decode($input, true);
-if (!is_array($data)) {
-    http_response_code(400);
-    echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
-    exit;
-}
-
-$userId = $data['personalData']['user_id'] ?? $data['user_id'] ?? ($_POST['user_id'] ?? 1);
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
 
 try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
+        exit;
+    }
+
+    $userId = $data['personalData']['user_id'] ?? $data['user_id'] ?? ($_POST['user_id'] ?? 1);
+
     $pdo->beginTransaction();
 
     if (isset($data['personalData'])) {
@@ -95,10 +100,10 @@ try {
     }
 
     $pdo->commit();
-    header('Content-Type: application/json');
     echo json_encode(['status' => 'ok']);
-} catch (Exception $e) {
+} catch (Throwable $e) {
     $pdo->rollBack();
+    error_log(__FILE__ . ' - ' . $e->getMessage());
     http_response_code(500);
     echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
 }


### PR DESCRIPTION
## Summary
- add global error handlers and JSON error responses in PHP helpers
- return structured errors for admin and user endpoints

## Testing
- `php -l admin_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c53ffb12c8326a8660ceb3eea2eed