### PR TITLE
Add cascading deletes to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ algorithm.
 Each `email` in `admins_agents` must be unique, enforced by a `UNIQUE(email)`
 constraint in the schema.
 
+Foreign keys from tables such as `transactions`, `deposits`, `retraits` and
+`tradingHistory` now include `ON DELETE CASCADE`. Removing a row from
+`personal_data` will automatically clean up any related records, preventing
+foreign key errors.
+
 ## Wallet management
 
 Each wallet row includes edit and delete icons. Clicking the **edit** icon opens

--- a/createtable.sql
+++ b/createtable.sql
@@ -62,8 +62,10 @@ CREATE TABLE transactions (
     status TEXT,
     statusClass TEXT,
     UNIQUE(operationNumber),
-    FOREIGN KEY (user_id) REFERENCES personal_data(user_id),
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (admin_id) REFERENCES admins_agents(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE TABLE notifications (
@@ -87,8 +89,10 @@ CREATE TABLE deposits (
     status TEXT,
     statusClass TEXT,
     UNIQUE(operationNumber),
-    FOREIGN KEY (user_id) REFERENCES personal_data(user_id),
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (admin_id) REFERENCES admins_agents(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE TABLE retraits (
@@ -102,8 +106,10 @@ CREATE TABLE retraits (
     status TEXT,
     statusClass TEXT,
     UNIQUE(operationNumber),
-    FOREIGN KEY (user_id) REFERENCES personal_data(user_id),
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (admin_id) REFERENCES admins_agents(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE TABLE tradingHistory (
@@ -122,8 +128,10 @@ CREATE TABLE tradingHistory (
     profitPerte DECIMAL(18,2),
     profitClass TEXT,
     UNIQUE(operationNumber),
-    FOREIGN KEY (user_id) REFERENCES personal_data(user_id),
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
+        ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (admin_id) REFERENCES admins_agents(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 CREATE TABLE loginHistory (


### PR DESCRIPTION
## Summary
- modify foreign key references to clean up related records automatically
- mention ON DELETE CASCADE behavior in documentation

## Testing
- `php -l getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c59609e0c832698245a4c2c5f534f