### PR TITLE
Fix editing user failing due to body read twice

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1309,10 +1309,10 @@
                 body: JSON.stringify({ action: 'update_user', user: user })
             });
             let result;
+            const txt = await res.text();
             try {
-                result = await res.json();
+                result = JSON.parse(txt);
             } catch (err) {
-                const txt = await res.text();
                 console.error('Invalid JSON', txt);
                 alert('Erreur serveur');
                 return;


### PR DESCRIPTION
## Summary
- fix response parsing when saving an edited user so that the body is only read once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c61357a8c832686ccd6c0044082c2