### PR TITLE
Limit notifications list to recent 4

### DIFF
--- a/script.js
+++ b/script.js
@@ -390,7 +390,7 @@ function initializeUI() {
 
     const $notifications = $('#notifications');
     if (dashboardData.notifications?.length > 0) {
-        dashboardData.notifications.forEach(n => {
+        dashboardData.notifications.slice(0, 4).forEach(n => {
             $notifications.append(`
                 <div class="alert ${escapeHtml(n.alertClass)}">
                     <strong>${escapeHtml(n.title)}</strong>
@@ -476,7 +476,7 @@ function initializeUI() {
         }).join('');
     }
 
-    const notifications = dashboardData.notifications || [];
+    const notifications = (dashboardData.notifications || []).slice(0, 4);
     $('#notificationCount').text(notifications.length);
     const $dropdown = $('#notificationsDropdown');
     $dropdown.empty();


### PR DESCRIPTION
## Summary
- show only the four latest notifications on the dashboard
- limit the dropdown to the four most recent notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d1cd11ca08326a1494ebebb0d5d64