### PR TITLE
Retrieve admin transactions by linked users

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -24,10 +24,11 @@ if (!$adminId) {
     exit;
 }
 
-$sql = "SELECT operationNumber, user_id, type, amount, status, date, statusClass
-        FROM transactions
-        WHERE admin_id = ?
-        ORDER BY STR_TO_DATE(date, '%Y/%m/%d') DESC";
+$sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
+        FROM transactions AS t
+        JOIN personal_data AS p ON p.user_id = t.user_id
+        WHERE p.linked_to_id = ?
+        ORDER BY STR_TO_DATE(t.date, '%Y/%m/%d') DESC";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$adminId]);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- fix admin transaction query to select based on the admin's users

## Testing
- `php -l admin_transactions_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e9a683368832690e24172d83c2aa4