### PR TITLE
Fix transaction history limit

### DIFF
--- a/script.js
+++ b/script.js
@@ -423,7 +423,7 @@ function initializeUI() {
             status,
             statusClass
         });
-        dashboardData.transactions = dashboardData.transactions.slice(0, 10);
+        // keep full history for persistence; UI will limit display to 10
     }
 
     function renderRecentTransactions() {
@@ -773,7 +773,7 @@ function initializeUI() {
                     status: 'En cours',
                     statusClass: 'bg-warning'
                 });
-                dashboardData.retraits = dashboardData.retraits.slice(0, 10);
+                // retain full withdrawal history; display will cap items
                 addTransactionRecord('Retrait', amt, 'En cours', 'bg-warning', opNumR);
                 renderWithdrawHistory();
                 renderRecentTransactions();
@@ -826,7 +826,7 @@ function initializeUI() {
                     status: 'En cours',
                     statusClass: 'bg-warning'
                 });
-                dashboardData.deposits = dashboardData.deposits.slice(0, 10);
+                // keep full deposit history; interface truncates to latest
                 renderDepositHistory();
                 addTransactionRecord('Dépôt', amt, 'En cours', 'bg-warning', opNumD);
                 renderRecentTransactions();

--- a/setter.php
+++ b/setter.php
@@ -65,23 +65,37 @@ try {
     ];
 
     foreach ($tables as $table => $cols) {
-        $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$userId]);
-        if (isset($data[$table]) && is_array($data[$table])) {
-            $hasAdmin = in_array($table, ['transactions','deposits','retraits','tradingHistory']);
-            $extra = $hasAdmin ? ',admin_id' : '';
-            $place = '(' . implode(',', array_fill(0, count($cols)+1 + ($hasAdmin ? 1 : 0), '?')) . ')';
-            $sql = "INSERT INTO $table (user_id$extra," . implode(',', $cols) . ") VALUES $place";
-            $stmt = $pdo->prepare($sql);
-            foreach ($data[$table] as $row) {
-                $values = [$userId];
-                if ($hasAdmin) {
-                    $values[] = $adminId;
-                }
-                foreach ($cols as $c) {
-                    $values[] = $row[$c] ?? null;
-                }
-                $stmt->execute($values);
+        if (!isset($data[$table]) || !is_array($data[$table])) {
+            continue;
+        }
+
+        $hasAdmin = in_array($table, ['transactions','deposits','retraits','tradingHistory']);
+        $colList = 'user_id' . ($hasAdmin ? ',admin_id' : '') . ',' . implode(',', $cols);
+        $place = '(' . implode(',', array_fill(0, count($cols) + 1 + ($hasAdmin ? 1 : 0), '?')) . ')';
+
+        $updateCols = [];
+        if (in_array($table, ['transactions','deposits','retraits','tradingHistory'])) {
+            if ($hasAdmin) $updateCols[] = 'admin_id = VALUES(admin_id)';
+            foreach ($cols as $c) {
+                $updateCols[] = "$c = VALUES($c)";
             }
+            $onDup = ' ON DUPLICATE KEY UPDATE ' . implode(',', $updateCols);
+        } else {
+            $onDup = '';
+        }
+
+        $sql = "INSERT INTO $table ($colList) VALUES $place$onDup";
+        $stmt = $pdo->prepare($sql);
+
+        foreach ($data[$table] as $row) {
+            $values = [$userId];
+            if ($hasAdmin) {
+                $values[] = $adminId;
+            }
+            foreach ($cols as $c) {
+                $values[] = $row[$c] ?? null;
+            }
+            $stmt->execute($values);
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve all transactions on the client
- keep entire deposit and withdrawal history
- store new rows without deleting old ones

## Testing
- `php -l setter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9cb098048326887ca51ada62ae8e