### PR TITLE
Show admin transactions

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -29,12 +29,22 @@ $pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
 $pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
 $offset = ($page - 1) * $pageSize;
 
+$placeholders = [];
+$linkedIds = [$adminId];
+$agentsStmt = $pdo->prepare('SELECT id FROM admins_agents WHERE created_by = ?');
+$agentsStmt->execute([$adminId]);
+$agentIds = $agentsStmt->fetchAll(PDO::FETCH_COLUMN);
+if ($agentIds) {
+    $linkedIds = array_merge($linkedIds, $agentIds);
+}
+$placeholders = implode(',', array_fill(0, count($linkedIds), '?'));
+
 $baseSql = "FROM transactions AS t
         JOIN personal_data AS p ON p.user_id = t.user_id
-        WHERE p.linked_to_id = ?";
+        WHERE p.linked_to_id IN ($placeholders)";
 
 $countStmt = $pdo->prepare("SELECT COUNT(*) $baseSql");
-$countStmt->execute([$adminId]);
+$countStmt->execute($linkedIds);
 $total = (int)$countStmt->fetchColumn();
 
 $sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
@@ -42,7 +52,7 @@ $sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date,
         ORDER BY STR_TO_DATE(t.date, '%Y/%m/%d') DESC
         LIMIT ? OFFSET ?";
 $stmt = $pdo->prepare($sql);
-$stmt->execute([$adminId, $pageSize, $offset]);
+$stmt->execute(array_merge($linkedIds, [$pageSize, $offset]));
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 echo json_encode(['transactions' => $rows, 'total' => $total, 'page' => $page, 'page_size' => $pageSize]);

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -381,7 +381,7 @@
                             <div class="card-header">
                                 <div class="row align-items-center">
                                     <div class="col-md-6">
-                                        <h5 class="mb-0">Transactions Récentes</h5>
+                                        <h5 class="mb-0">Transactions Récentes (10 par page)</h5>
                                     </div>
                                     <div class="col-md-6">
                                         <div class="input-group">
@@ -1444,7 +1444,7 @@
 
         let ALL_TXS = [];
         let TX_PAGE = 1;
-        const TX_PAGE_SIZE = 10;
+        const TX_PAGE_SIZE = 10; // nombre d'entrées par page
         let TX_TOTAL_PAGES = 1;
 
         function renderTransactions() {


### PR DESCRIPTION
## Summary
- allow admins to fetch transactions for all their agents
- show the page size in the admin dashboard header
- clarify transaction page size constant in inline JS

## Testing
- `php -l admin_transactions_getter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea7dca71c832681654ae045110dbb