### PR TITLE
Fix admin transactions limit query

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -49,12 +49,15 @@ $countStmt = $pdo->prepare("SELECT COUNT(*) $baseSql");
 $countStmt->execute($linkedIds);
 $total = (int)$countStmt->fetchColumn();
 
-$sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
+    // MySQL doesn't allow binding parameters for LIMIT/OFFSET reliably when
+    // using emulated prepares. Since the values are cast to integers above
+    // it is safe to directly inject them into the SQL string.
+    $sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
         $baseSql
         ORDER BY STR_TO_DATE(t.date, '%Y/%m/%d') DESC
-        LIMIT ? OFFSET ?";
-$stmt = $pdo->prepare($sql);
-$stmt->execute(array_merge($linkedIds, [$pageSize, $offset]));
+        LIMIT $pageSize OFFSET $offset";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($linkedIds);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 echo json_encode(['transactions' => $rows, 'total' => $total, 'page' => $page, 'page_size' => $pageSize]);


### PR DESCRIPTION
## Summary
- update admin_transactions_getter.php to inline LIMIT/OFFSET values
- add comments describing why parameters are injected

## Testing
- `php` was not available, so no syntax check could be performed

------
https://chatgpt.com/codex/tasks/task_e_686eabc3f6508326bdbe5a65422b52bd