### PR TITLE
Show more admin transactions

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -27,8 +27,8 @@ if (!$adminId) {
 }
 
 $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
-$pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
-$pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
+$pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 100;
+$pageSize = $pageSize > 0 ? min($pageSize, 1000) : 100;
 $offset = ($page - 1) * $pageSize;
 
 $placeholders = [];

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1444,7 +1444,7 @@
 
         let ALL_TXS = [];
         let TX_PAGE = 1;
-        const TX_PAGE_SIZE = 10; // nombre d'entrées par page
+        const TX_PAGE_SIZE = 100; // nombre d'entrées par page
         let TX_TOTAL_PAGES = 1;
 
         function renderTransactions() {


### PR DESCRIPTION
## Summary
- raise the number of transactions returned by default
- request 100 transactions from the admin dashboard

## Testing
- `php -l admin_transactions_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eaf3135308326af26e5af24517bc9