### PR TITLE
Add paginated transaction history

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -388,27 +388,27 @@
 </div>
 <div class="row mt-4">
 <div class="col-md-8">
-<div class="card" id="dernierestransactionsCard">
-<div class="card-header" id="dernierestransactionsHeader">
-<i class="fas fa-history me-2"></i> Dernières transactions
-                    </div>
-<div class="card-body">
-<div class="table-responsive">
-<table id="dernierestransactionstable" class="table table-hover">
-<thead>
-<tr>
-<th>Numéro Opération</th>
-<th>Type</th>
-<th>Montant</th>
-<th>Date</th>
-<th>Statut</th>
-</tr>
-</thead>
-  <tbody id="transactionsRecents">
-  </tbody>
-</table>
-</div>
-</div>
+<div class="card" id="transactionsCard">
+  <div class="card-header" id="transactionsHeader">
+    <i class="fas fa-history me-2"></i> Toutes les transactions
+  </div>
+  <div class="card-body">
+    <div class="table-responsive">
+      <table id="transactionsTable" class="table table-hover">
+        <thead>
+          <tr>
+            <th>Numéro Opération</th>
+            <th>Type</th>
+            <th>Montant</th>
+            <th>Date</th>
+            <th>Statut</th>
+          </tr>
+        </thead>
+        <tbody id="transactionsTableBody"></tbody>
+      </table>
+    </div>
+    <ul class="pagination justify-content-center mt-3" id="transactionsPagination"></ul>
+  </div>
 </div>
 </div>
 <div class="col-md-4">

--- a/script.js
+++ b/script.js
@@ -426,11 +426,18 @@ function initializeUI() {
         // keep full history for persistence; UI will limit display to 10
     }
 
-    function renderRecentTransactions() {
-        const $tbody = $('#transactionsRecents');
+    let TX_PAGE = 1;
+    const TX_PAGE_SIZE = 10;
+    let TX_TOTAL_PAGES = 1;
+    let ALL_TXS = [];
+
+    function renderTransactions() {
+        const $tbody = $('#transactionsTableBody');
         $tbody.empty();
-        if (dashboardData.transactions?.length > 0) {
-            dashboardData.transactions.slice(0, 5).forEach(t => {
+        if (ALL_TXS.length === 0) {
+            $tbody.html('<tr><td colspan="5" class="text-center">Aucune donnée disponible</td></tr>');
+        } else {
+            ALL_TXS.forEach(t => {
                 $tbody.append(`
                     <tr>
                         <td>${escapeHtml(t.operationNumber)}</td>
@@ -440,8 +447,29 @@ function initializeUI() {
                         <td><span class="badge ${escapeHtml(t.statusClass)}">${escapeHtml(t.status)}</span></td>
                     </tr>`);
             });
-        } else {
-            $tbody.html('<tr><td colspan="5" class="text-center">Aucune donnée disponible</td></tr>');
+        }
+        const $pag = $('#transactionsPagination');
+        if ($pag.length) {
+            $pag.empty();
+            const prevClass = TX_PAGE === 1 ? 'disabled' : '';
+            $pag.append(`<li class="page-item ${prevClass}"><a class="page-link" href="#" data-page="${TX_PAGE - 1}">Précédent</a></li>`);
+            for (let i = 1; i <= TX_TOTAL_PAGES; i++) {
+                const active = i === TX_PAGE ? 'active' : '';
+                $pag.append(`<li class="page-item ${active}"><a class="page-link" href="#" data-page="${i}">${i}</a></li>`);
+            }
+            const nextClass = TX_PAGE === TX_TOTAL_PAGES ? 'disabled' : '';
+            $pag.append(`<li class="page-item ${nextClass}"><a class="page-link" href="#" data-page="${TX_PAGE + 1}">Suivant</a></li>`);
+        }
+    }
+
+    async function loadTransactions() {
+        try {
+            const data = await apiFetch(`user_transactions_getter.php?user_id=${encodeURIComponent(userId)}&page=${TX_PAGE}&page_size=${TX_PAGE_SIZE}`);
+            ALL_TXS = data.transactions || [];
+            TX_TOTAL_PAGES = Math.ceil((data.total || 0) / TX_PAGE_SIZE) || 1;
+            renderTransactions();
+        } catch (err) {
+            console.error('Failed to load transactions', err);
         }
     }
 
@@ -776,7 +804,7 @@ function initializeUI() {
                 // retain full withdrawal history; display will cap items
                 addTransactionRecord('Retrait', amt, 'En cours', 'bg-warning', opNumR);
                 renderWithdrawHistory();
-                renderRecentTransactions();
+                loadTransactions();
                 showBootstrapAlert('withdrawAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
                 saveDashboardData();
             }
@@ -829,7 +857,7 @@ function initializeUI() {
                 // keep full deposit history; interface truncates to latest
                 renderDepositHistory();
                 addTransactionRecord('Dépôt', amt, 'En cours', 'bg-warning', opNumD);
-                renderRecentTransactions();
+                loadTransactions();
                 showBootstrapAlert('depositAlert', 'Votre demande sera traitée dans les plus brefs délais.', 'success');
                 saveDashboardData();
             }
@@ -1095,7 +1123,7 @@ function initializeUI() {
 
     renderDepositHistory();
     renderWithdrawHistory();
-    renderRecentTransactions();
+    loadTransactions();
 
     const apiPairs = {
         BTCUSD: 'BTCUSDT',
@@ -1171,7 +1199,7 @@ function initializeUI() {
         addTransactionRecord('Trading', order.montant, order.statut, order.statutClass, order.operationNumber);
         saveDashboardData();
         renderTradingHistory();
-        renderRecentTransactions();
+        loadTransactions();
     }
 
     function finalizeOrder(order, exitPrice) {
@@ -1207,7 +1235,7 @@ function initializeUI() {
         saveDashboardData();
         updateBalances();
         renderTradingHistory();
-        renderRecentTransactions();
+        loadTransactions();
     }
 
     function completeOrder(order) {
@@ -1447,4 +1475,12 @@ function initializeUI() {
     } else {
         $loginHistoryBody.html('<tr><td colspan="3" class="text-center">Aucune donnée disponible</td></tr>');
     }
-};
+
+    $('#transactionsPagination').on('click', 'a', function(e) {
+        e.preventDefault();
+        const page = parseInt($(this).data('page'));
+        if (!isNaN(page)) {
+            TX_PAGE = page;
+            loadTransactions();
+        }
+    });};

--- a/user_transactions_getter.php
+++ b/user_transactions_getter.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
+    $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+    $pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
+    $pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
+    $offset = ($page - 1) * $pageSize;
+
+    $countStmt = $pdo->prepare('SELECT COUNT(*) FROM transactions WHERE user_id = ?');
+    $countStmt->execute([$userId]);
+    $total = (int)$countStmt->fetchColumn();
+
+    // Safe to inject integers directly for LIMIT/OFFSET
+    $sql = "SELECT operationNumber, type, amount, date, status, statusClass
+            FROM transactions WHERE user_id = ?
+            ORDER BY STR_TO_DATE(date, '%Y/%m/%d') DESC, id DESC
+            LIMIT $pageSize OFFSET $offset";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$userId]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode(['transactions' => $rows, 'total' => $total, 'page' => $page, 'page_size' => $pageSize]);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- display a full transaction table on the user dashboard
- load transactions from the backend with pagination
- add a new `user_transactions_getter.php` endpoint

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb8e406e08326846ba81b0b7c59d4