### PR TITLE
Implement pagination for admin transaction list

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -27,8 +27,8 @@ if (!$adminId) {
 }
 
 $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
-$pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 100;
-$pageSize = $pageSize > 0 ? min($pageSize, 1000) : 100;
+$pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
+$pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
 $offset = ($page - 1) * $pageSize;
 
 $placeholders = [];

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -252,11 +252,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="card-footer">
-                                <nav>
-                                    <ul class="pagination justify-content-center mb-0" id="transactionsPagination"></ul>
-                                </nav>
-                            </div>
                         </div>
                     </div>
                     
@@ -425,12 +420,17 @@
                                                 <th>Actions</th>
                                             </tr>
                                         </thead>
-                                        <tbody id="transactionsTableBody"></tbody>
-                                    </table>
-                                </div>
+                                    <tbody id="transactionsTableBody"></tbody>
+                                </table>
                             </div>
                         </div>
+                        <div class="card-footer">
+                            <nav>
+                                <ul class="pagination justify-content-center mb-0" id="transactionsPagination"></ul>
+                            </nav>
+                        </div>
                     </div>
+                </div>
                     
                     <!-- KYC Section -->
                     <div id="kyc-section" class="content-section">
@@ -1444,7 +1444,7 @@
 
         let ALL_TXS = [];
         let TX_PAGE = 1;
-        const TX_PAGE_SIZE = 100; // nombre d'entrées par page
+        const TX_PAGE_SIZE = 10; // nombre d'entrées par page
         let TX_TOTAL_PAGES = 1;
 
         function renderTransactions() {


### PR DESCRIPTION
## Summary
- add pagination controls to the admin transaction table
- default to 10 transactions per page
- adjust backend default page size for admin transactions

## Testing
- `php -l admin_transactions_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc076d708326a76fbf93eda6fac0