### PR TITLE
Enable searching across all transactions

### DIFF
--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -30,6 +30,7 @@ $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
 $pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
 $pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
 $offset = ($page - 1) * $pageSize;
+$search = isset($_GET['search']) ? trim($_GET['search']) : '';
 
 $placeholders = [];
 $linkedIds = [$targetId];
@@ -41,12 +42,19 @@ if ($agentIds) {
 }
 $placeholders = implode(',', array_fill(0, count($linkedIds), '?'));
 
+
 $baseSql = "FROM transactions AS t
         JOIN personal_data AS p ON p.user_id = t.user_id
         WHERE p.linked_to_id IN ($placeholders)";
 
+$params = $linkedIds;
+if ($search !== '') {
+    $baseSql .= " AND t.operationNumber LIKE ?";
+    $params[] = '%' . $search . '%';
+}
+
 $countStmt = $pdo->prepare("SELECT COUNT(*) $baseSql");
-$countStmt->execute($linkedIds);
+$countStmt->execute($params);
 $total = (int)$countStmt->fetchColumn();
 
     // MySQL doesn't allow binding parameters for LIMIT/OFFSET reliably when
@@ -57,7 +65,7 @@ $total = (int)$countStmt->fetchColumn();
         ORDER BY STR_TO_DATE(t.date, '%Y/%m/%d') DESC
         LIMIT $pageSize OFFSET $offset";
     $stmt = $pdo->prepare($sql);
-    $stmt->execute($linkedIds);
+    $stmt->execute($params);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 echo json_encode(['transactions' => $rows, 'total' => $total, 'page' => $page, 'page_size' => $pageSize]);

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1516,7 +1516,14 @@
 
         async function loadTransactions() {
             try {
-                const res = await fetchWithAuth(`admin_transactions_getter.php?page=${TX_PAGE}&page_size=${TX_PAGE_SIZE}`);
+                const searchInput = document.getElementById('txSearchInput');
+                const search = searchInput ? searchInput.value.trim() : '';
+                const params = new URLSearchParams({
+                    page: TX_PAGE,
+                    page_size: TX_PAGE_SIZE
+                });
+                if (search) params.append('search', search);
+                const res = await fetchWithAuth(`admin_transactions_getter.php?${params.toString()}`);
                 const data = await res.json();
                 ALL_TXS = data.transactions || [];
                 TX_TOTAL_PAGES = Math.ceil((data.total || 0) / TX_PAGE_SIZE) || 1;
@@ -1563,7 +1570,10 @@
         const searchInput = document.getElementById('txSearchInput');
        if (typeSel) typeSel.addEventListener('change', () => { TX_PAGE = 1; renderTransactions(); });
        if (statusSel) statusSel.addEventListener('change', () => { TX_PAGE = 1; renderTransactions(); });
-        if (searchInput) searchInput.addEventListener('input', () => { TX_PAGE = 1; renderTransactions(); });
+        if (searchInput) searchInput.addEventListener('input', () => {
+            TX_PAGE = 1;
+            loadTransactions();
+        });
 
         const txPag = document.getElementById('transactionsPagination');
         if (txPag) txPag.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- support `search` query for admin transactions API
- pass search term from dashboard when loading transactions
- update search input to reload results from server

## Testing
- `php -l admin_transactions_getter.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ebec8dae48326a127c3d550065ef3