### PR TITLE
Fix user creation error with large IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This project uses small PHP helpers (`getter.php` and `setter.php`) to read and 
 The dashboard pages (`dashbord_user.html` and `script.js`) request data from `getter.php` and send updates to `setter.php`.
 `script.js` now fetches wallet addresses from `get_wallets.php`, which returns `SELECT * FROM wallets WHERE user_id = ?` in JSON. The `wallets` table stores
 crypto addresses with a `BIGINT` `id` so each entry keeps the unique identifier
-generated in JavaScript with `Date.now()`.
+generated in JavaScript with `Date.now()`. User accounts use the same approach:
+the `personal_data.user_id` column is also a `BIGINT` so IDs created with
+`Date.now()` are inserted without overflowing.
 
 The `personal_data` table now includes columns for storing default bank details:
 `userBankName`, `userAccountName`, `userAccountNumber`, `userIban` and

--- a/createtable.sql
+++ b/createtable.sql
@@ -8,7 +8,7 @@ CREATE TABLE admins_agents (
 );
 
 CREATE TABLE personal_data (
-    user_id INTEGER PRIMARY KEY,
+    user_id BIGINT PRIMARY KEY,
     balance DECIMAL(18,2),
     totalDepots DECIMAL(18,2),
     totalRetraits DECIMAL(18,2),
@@ -44,7 +44,7 @@ CREATE TABLE personal_data (
 
 CREATE TABLE wallets (
     id BIGINT PRIMARY KEY,
-    user_id INTEGER,
+    user_id BIGINT,
     currency TEXT,
     network TEXT,
     address TEXT,
@@ -53,7 +53,7 @@ CREATE TABLE wallets (
 
 CREATE TABLE transactions (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     admin_id INTEGER,
     operationNumber TEXT,
     type TEXT,
@@ -70,7 +70,7 @@ CREATE TABLE transactions (
 
 CREATE TABLE notifications (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     type TEXT,
     title TEXT,
     message TEXT,
@@ -80,7 +80,7 @@ CREATE TABLE notifications (
 
 CREATE TABLE deposits (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     admin_id INTEGER,
     operationNumber TEXT,
     date TEXT,
@@ -97,7 +97,7 @@ CREATE TABLE deposits (
 
 CREATE TABLE retraits (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     admin_id INTEGER,
     operationNumber TEXT,
     date TEXT,
@@ -114,7 +114,7 @@ CREATE TABLE retraits (
 
 CREATE TABLE tradingHistory (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     admin_id INTEGER,
     operationNumber TEXT,
     temps TEXT,
@@ -136,14 +136,14 @@ CREATE TABLE tradingHistory (
 
 CREATE TABLE loginHistory (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER,
+    user_id BIGINT,
     date TEXT,
     ip TEXT,
     device TEXT
 );
 
 CREATE TABLE bank_withdrawl_info (
-    user_id INTEGER PRIMARY KEY,
+    user_id BIGINT PRIMARY KEY,
     widhrawBankName TEXT,
     widhrawAccountName TEXT,
     widhrawAccountNumber TEXT,


### PR DESCRIPTION
## Summary
- allow large user ids by using `BIGINT` type in DB schema
- document that `personal_data.user_id` is now `BIGINT`

## Testing
- `php -l admin_setter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef6e0305c83268b79cc85a50be98d