### PR TITLE
Add user login page and integrate with dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ Use `admin_login.php` to sign in. POST `email` and `password`; a successful logi
 
 `dashboard_admin.html` now embeds its own login form. You can also sign in by POSTing `email` and `password` to `admin_login.php`. If the credentials are valid the endpoint creates a session and sets a cookie storing `admin_id`. Keep this cookie for all subsequent calls to `admin_getter.php` and other admin actions so the server knows who you are. Tools like `curl -c cookies.txt -b cookies.txt` can handle the cookie automatically.
 
+
+## User Login
+
+`dashbord_user.html` now includes a login form. Submit your email and password to `user_login.php`; on success the script stores your `user_id` in `localStorage` and loads the dashboard for that account.

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -13,7 +13,21 @@
 <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
-<div class="container-fluid">
+<div id="loginSection" class="container mt-5" style="max-width: 400px; display:none;">
+  <h2 class="mb-3">Connexion</h2>
+  <form id="userLoginForm">
+    <div class="mb-3">
+      <label for="loginEmail" class="form-label">Email</label>
+      <input type="email" class="form-control" id="loginEmail" required>
+    </div>
+    <div class="mb-3">
+      <label for="loginPassword" class="form-label">Mot de passe</label>
+      <input type="password" class="form-control" id="loginPassword" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Se connecter</button>
+  </form>
+</div>
+<div id="dashboardContainer" class="container-fluid" style="display:none;">
 <div class="row">
 <!-- Sidebar -->
 <div class="col-md-3 col-lg-2 sidebar p-0">

--- a/script.js
+++ b/script.js
@@ -1,12 +1,12 @@
 let dashboardData = null;
-// Retrieve the current user ID from localStorage. Fallback to 1 if not found.
+// Retrieve the current user ID from localStorage if available.
 let userId;
 try {
     userId = localStorage.getItem('user_id');
 } catch (e) {
     userId = null;
 }
-userId = userId || 1;
+userId = userId ? parseInt(userId) : null;
 
 // Utility functions
 function parseDollar(str) {
@@ -161,9 +161,42 @@ async function saveDashboardData() {
 }
 
 $(document).ready(async function () {
-    await fetchDashboardData();
-    await fetchWallets();
+    if (userId) {
+        $("#loginSection").hide();
+        $("#dashboardContainer").show();
+        await fetchDashboardData();
+        await fetchWallets();
+    } else {
+        $("#dashboardContainer").hide();
+        $("#loginSection").show();
+    }
 });
+$("#userLoginForm").on("submit", async function(e){
+    e.preventDefault();
+    const email = $("#loginEmail").val().trim();
+    const pwd = $("#loginPassword").val();
+    const formData = new FormData();
+    formData.append("email", email);
+    formData.append("password", md5(pwd));
+    const res = await fetch("user_login.php", { method: "POST", body: formData });
+    const result = await res.json();
+    if(result.status === "ok") {
+        userId = result.user_id;
+        try { localStorage.setItem("user_id", userId); } catch(e){}
+        $("#loginSection").hide();
+        $("#dashboardContainer").show();
+        await fetchDashboardData();
+        await fetchWallets();
+    } else {
+        alert("Échec de la connexion");
+    }
+});
+function logout(){
+    try { localStorage.removeItem("user_id"); } catch(e){}
+    location.reload();
+}
+
+
 
 function initializeUI() {
     dashboardData.personalData.wallets = dashboardData.wallets || dashboardData.personalData.wallets || [];

--- a/user_login.php
+++ b/user_login.php
@@ -1,0 +1,39 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    if (!$email || !$password) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Missing credentials']);
+        exit;
+    }
+
+    $stmt = $pdo->prepare('SELECT user_id, passwordHash FROM personal_data WHERE emailaddress = ? LIMIT 1');
+    $stmt->execute([$email]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($row && hash_equals($row['passwordHash'], $password)) {
+        session_start();
+        $_SESSION['user_id'] = $row['user_id'];
+        echo json_encode(['status' => 'ok', 'user_id' => (int)$row['user_id']]);
+        exit;
+    }
+
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid email or password']);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add `user_login.php` endpoint for authenticating users
- integrate login form into `dashbord_user.html`
- update `script.js` to handle user login/logout and hide dashboard until logged in
- document the new login flow in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68700efccda88326a439178d15e548dd