### PR TITLE
Add note field for user creation

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -51,7 +51,7 @@ try {
         'loginAlerts','transactionAlerts','twoFactorAuth','emailaddress','address',
         'phone','dob','nationality','created_at','btcAddress','ethAddress','usdtAddress',
         'userBankName','userAccountName','userAccountNumber','userIban','userSwiftCode',
-        'linked_to_id'
+        'note','linked_to_id'
     ];
 
     $action = $data['action'] ?? '';

--- a/createtable.sql
+++ b/createtable.sql
@@ -39,6 +39,7 @@ CREATE TABLE personal_data (
     userAccountNumber TEXT,
     userIban TEXT,
     userSwiftCode TEXT,
+    note TEXT,
     linked_to_id INTEGER
 );
 

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -569,6 +569,10 @@
                                 <input type="password" class="form-control" id="confirmPassword" required>
                             </div>
                         </div>
+                        <div class="mb-3">
+                            <label for="userNote" class="form-label">Note</label>
+                            <textarea class="form-control" id="userNote" rows="3"></textarea>
+                        </div>
                         <!-- role field removed: user creation always creates a standard account -->
                     </form>
                 </div>
@@ -1149,6 +1153,7 @@
             const firstName = document.getElementById('firstName').value.trim();
             const lastName = document.getElementById('lastName').value.trim();
             const email = document.getElementById('email').value.trim();
+            const note = document.getElementById('userNote').value.trim();
 
             const payload = {
                 action: 'create_user',
@@ -1156,6 +1161,7 @@
                     user_id: Date.now(),
                     fullName: firstName + ' ' + lastName,
                     emailaddress: email,
+                    note: note,
                     password: md5(password),
                     linked_to_id: ADMIN_ID
                 }

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -10,7 +10,7 @@ INSERT INTO personal_data VALUES (
 '2025-06-11', 'ca', '2025-01-01', 
 '0xABC123...', 'TRc123456...', 'USDT123...', 
 'Bank of Earth', 'Ahmed Kouraychi', 
-'ACC123456', 'IBAN123456', 'SWIFT123', 1
+'ACC123456', 'IBAN123456', 'SWIFT123', '', 1
 );
 
 


### PR DESCRIPTION
## Summary
- allow saving a note with each user
- capture note in the admin dashboard form
- store note when creating users
- update schema and sample data

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701d353c708326812fcc3737fd4c97