### PR TITLE
Improve admin deletion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ present, the request is rejected with `401 Unauthorized`. Once authenticated,
 `dashboard_admin.html` will display the admin's agents and associated users.
 Use the "Créer Agent" form to add new agents under the logged‑in admin.
 
+Deleting an agent with `admin_setter.php` now removes all of the users tied to
+that account. Each affected user's rows in `personal_data`, `wallets`,
+`transactions`, `tradingHistory`, `notifications`, `loginHistory`, `deposits`
+and `bank_withdrawl_info` are deleted before the agent record itself is
+removed. The same cleanup occurs when deleting an individual user.
+
 Use `admin_login.php` to sign in. POST `email` and `password`; a successful login starts a session and stores `admin_id` for subsequent requests.
 
 ## Admin Login

--- a/admin_setter.php
+++ b/admin_setter.php
@@ -146,9 +146,31 @@ try {
         if (!$id) {
             throw new Exception('Missing id');
         }
-        $stmt = $pdo->prepare('DELETE FROM admins_agents WHERE id = ?');
-        $stmt->execute([$id]);
-        echo json_encode(['status' => 'ok']);
+        $pdo->beginTransaction();
+        try {
+            $stmt = $pdo->prepare('SELECT user_id FROM personal_data WHERE linked_to_id = ?');
+            $stmt->execute([$id]);
+            $userIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+            if ($userIds) {
+                $tables = [
+                    'wallets', 'transactions', 'notifications', 'deposits',
+                    'retraits', 'tradingHistory', 'loginHistory',
+                    'bank_withdrawl_info', 'personal_data'
+                ];
+                foreach ($userIds as $uid) {
+                    foreach ($tables as $table) {
+                        $pdo->prepare("DELETE FROM $table WHERE user_id = ?")->execute([$uid]);
+                    }
+                }
+            }
+            $stmt = $pdo->prepare('DELETE FROM admins_agents WHERE id = ?');
+            $stmt->execute([$id]);
+            $pdo->commit();
+            echo json_encode(['status' => 'ok']);
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
     } elseif ($action === 'delete_user') {
         $userId = isset($data['user_id']) ? (int)$data['user_id'] : 0;
         if (!$userId) {


### PR DESCRIPTION
## Summary
- cascade delete user data when deleting an admin/agent
- document new cleanup behaviour

## Testing
- `php -l admin_setter.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687042c8db5483268fcdb83014f5d7e4