### PR TITLE
Fix duplicate user notifications

### DIFF
--- a/getter.php
+++ b/getter.php
@@ -26,7 +26,7 @@ $data = [
     'personalData' => $personal,
     'wallets' => fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]),
     'transactions' => fetchAll($pdo, 'SELECT operationNumber,type,amount,date,status,statusClass FROM transactions WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
-    'notifications' => fetchAll($pdo, 'SELECT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC', [$userId]),
+    'notifications' => fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC', [$userId]),
     'deposits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'retraits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'tradingHistory' => fetchAll($pdo, 'SELECT operationNumber,temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass FROM tradingHistory WHERE user_id = ? ORDER BY id DESC LIMIT 5', [$userId]),

--- a/script.js
+++ b/script.js
@@ -573,6 +573,7 @@ function initializeUI() {
     updateCounters();
 
     const $notifications = $('#notifications');
+    $notifications.empty();
     if (dashboardData.notifications?.length > 0) {
         dashboardData.notifications.slice(0, 4).forEach(n => {
             $notifications.append(`


### PR DESCRIPTION
## Summary
- ensure notifications container is cleared before rendering new items
- fetch unique notifications from database using DISTINCT

## Testing
- `php -l getter.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68704fee87ec83269132cb90bc5269c2