### PR TITLE
Add crypto name field to deposit addresses

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -115,10 +115,11 @@ try {
         }
 
         if (!empty($data['cryptoAddresses']) && is_array($data['cryptoAddresses'])) {
-            $stmt = $pdo->prepare('INSERT INTO deposit_crypto_address (user_id,wallet_info) VALUES (?,?)');
+            $stmt = $pdo->prepare('INSERT INTO deposit_crypto_address (user_id,crypto_name,wallet_info) VALUES (?,?,?)');
             foreach ($data['cryptoAddresses'] as $addr) {
                 $stmt->execute([
                     $user['user_id'] ?? null,
+                    $addr['crypto_name'] ?? '',
                     $addr['wallet_info'] ?? ''
                 ]);
             }
@@ -158,9 +159,9 @@ try {
 
         if (!empty($data['cryptoAddresses']) && is_array($data['cryptoAddresses'])) {
             $pdo->prepare('DELETE FROM deposit_crypto_address WHERE user_id = ?')->execute([$userId]);
-            $stmt = $pdo->prepare('INSERT INTO deposit_crypto_address (user_id,wallet_info) VALUES (?,?)');
+            $stmt = $pdo->prepare('INSERT INTO deposit_crypto_address (user_id,crypto_name,wallet_info) VALUES (?,?,?)');
             foreach ($data['cryptoAddresses'] as $addr) {
-                $stmt->execute([$userId, $addr['wallet_info'] ?? '']);
+                $stmt->execute([$userId, $addr['crypto_name'] ?? '', $addr['wallet_info'] ?? '']);
             }
         }
 

--- a/createtable.sql
+++ b/createtable.sql
@@ -152,6 +152,7 @@ CREATE TABLE bank_withdrawl_info (
 CREATE TABLE deposit_crypto_address (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     user_id BIGINT,
+    crypto_name TEXT,
     wallet_info TEXT,
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
         ON DELETE CASCADE ON UPDATE CASCADE

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1131,11 +1131,12 @@
             bar.classList.add(cls);
         }
 
-        function createCryptoRow(container, info = '', img = '') {
+        function createCryptoRow(container, crypto = '', info = '') {
             const div = document.createElement('div');
             div.className = 'row g-3 mb-2 crypto-row';
             div.innerHTML = `
-                <div class="col-md-10"><input type="text" class="form-control wallet-info" placeholder="Infos" value="${escapeHtml(info)}"></div>
+                <div class="col-md-5"><input type="text" class="form-control crypto-name" placeholder="Crypto" value="${escapeHtml(crypto)}"></div>
+                <div class="col-md-5"><input type="text" class="form-control wallet-info" placeholder="Adresse" value="${escapeHtml(info)}"></div>
                 <div class="col-md-2 d-flex align-items-center"><button type="button" class="btn btn-outline-danger remove-crypto-row">&times;</button></div>`;
             container.appendChild(div);
         }
@@ -1143,8 +1144,9 @@
         function gatherCryptoAddresses(containerId) {
             const arr = [];
             document.querySelectorAll('#' + containerId + ' .crypto-row').forEach(r => {
+                const name = r.querySelector('.crypto-name').value.trim();
                 const info = r.querySelector('.wallet-info').value.trim();
-                if (info) arr.push({ wallet_info: info });
+                if (name && info) arr.push({ crypto_name: name, wallet_info: info });
             });
             return arr;
         }
@@ -1466,7 +1468,7 @@
                     createCryptoRow(cryptoCont);
                 } else {
                     arrCrypto.forEach(a => {
-                        createCryptoRow(cryptoCont, a.wallet_info || '');
+                        createCryptoRow(cryptoCont, a.crypto_name || '', a.wallet_info || '');
                     });
                 }
                 new bootstrap.Modal(document.getElementById('editUserModal')).show();

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -570,17 +570,13 @@
 <div class="mb-4">
 <label class="form-label" for="cryptoCurrency">Choisissez la crypto-monnaie</label>
 <select class="form-select" id="cryptoCurrency">
-<option value="btc">Bitcoin</option>
-<option value="eth">Ethereum</option>
-<option value="usdt">Tether</option>
-<option value="usdc">USD Coin</option>
 </select>
 </div>
 <div class="card mb-4 bg-light">
 <div class="card-body text-center">
 <h5 class="card-title">Adresse du portefeuille</h5>
 <div class="qr-code bg-white p-3 d-inline-block mb-3">
-<img alt="QR Code" class="img-fluid" src="https://api.qrserver.com/v1/create-qr-code/?data={$encodedText}&size={$size}x{$size}"/>
+<img id="cryptoQR" alt="QR Code" class="img-fluid" src=""/>
 </div>
 <div class="input-group mb-3">
 <input class="form-control" id="cryptoDepositAddress" name="cryptoDepositAddress" readonly type="text" value=""/>

--- a/getter.php
+++ b/getter.php
@@ -32,7 +32,7 @@ $data = [
     'tradingHistory' => fetchAll($pdo, 'SELECT operationNumber,temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass FROM tradingHistory WHERE user_id = ? ORDER BY id DESC LIMIT 5', [$userId]),
     'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC', [$userId]),
     'bankWithdrawInfo' => $bankWithdraw,
-    'cryptoDepositAddresses' => fetchAll($pdo, 'SELECT id,wallet_info FROM deposit_crypto_address WHERE user_id = ?', [$userId]),
+    'cryptoDepositAddresses' => fetchAll($pdo, 'SELECT id,crypto_name,wallet_info FROM deposit_crypto_address WHERE user_id = ?', [$userId]),
     // placeholders for front-end
     'formData' => new stdClass(),
     'defaultKYCStatus' => [

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -12,10 +12,10 @@ INSERT INTO personal_data VALUES (
 'ACC123456', 'IBAN123456', 'SWIFT123', '', 1
 );
 
-INSERT INTO deposit_crypto_address (user_id, wallet_info) VALUES
-    (1, '0xABC123...'),
-    (1, 'TRc123456...'),
-    (1, 'USDT123...');
+INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES
+    (1, 'Bitcoin', '0xABC123...'),
+    (1, 'Tron', 'TRc123456...'),
+    (1, 'USDT', 'USDT123...');
 
 
 INSERT INTO wallets VALUES (

--- a/script.js
+++ b/script.js
@@ -511,6 +511,7 @@ function initializeUI() {
     fetchWallets();
 
     updatePlatformBankDetails();
+    populateCryptoDepositOptions();
 
     $.each(dashboardData.personalData || {}, function (id, value) {
         if (id === "passwordStrengthBar") {
@@ -1006,21 +1007,24 @@ function initializeUI() {
     $('#cryptoCurrency').on('change', populateCryptoNetwork);
     populateCryptoNetwork();
 
+    function populateCryptoDepositOptions() {
+        const $select = $('#cryptoCurrency');
+        $select.empty();
+        (dashboardData.cryptoDepositAddresses || []).forEach(a => {
+            $select.append(`<option value="${escapeHtml(a.wallet_info)}">${escapeHtml(a.crypto_name)}</option>`);
+        });
+        updateCryptoDepositAddress();
+    }
+
     function updateCryptoDepositAddress() {
-        const currency = $('#cryptoCurrency').val();
-        const key = currency + 'Address';
-        $('#cryptoDepositAddress').val(dashboardData.personalData[key] || '');
+        const addr = $('#cryptoCurrency').val() || '';
+        $('#cryptoDepositAddress').val(addr);
+        const src = 'https://api.qrserver.com/v1/create-qr-code/?data=' + encodeURIComponent(addr) + '&size=140x140';
+        $('#cryptoQR').attr('src', src);
     }
 
     $('#cryptoCurrency').on('change', updateCryptoDepositAddress);
-    $('#cryptoDepositAddress').on('input', function () {
-        const currency = $('#cryptoCurrency').val();
-        const key = currency + 'Address';
-        dashboardData.personalData[key] = $(this).val();
-        saveDashboardData();
-    });
 
-    updateCryptoDepositAddress();
 
     $(document).on('click', '.wallet-delete', async function () {
         const id = $(this).data('id');


### PR DESCRIPTION
## Summary
- store crypto name alongside wallet info in `deposit_crypto_address`
- expose crypto name in getters and admin forms
- update admin dashboard to manage crypto name
- populate user deposit page with available currencies and QR code

## Testing
- `php -l admin_setter.php`
- `php -l getter.php`

------
https://chatgpt.com/codex/tasks/task_e_6871abd690348326acb7d2d77dc5a05b