### PR TITLE
Fix deposit address loss

### DIFF
--- a/setter.php
+++ b/setter.php
@@ -29,7 +29,9 @@ try {
 
         $cols = array_keys($personal);
         $place = implode(',', array_fill(0, count($cols), '?'));
-        $sql = 'REPLACE INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ')';
+        $update = implode(',', array_map(fn($c) => "$c = VALUES($c)", $cols));
+        $sql = 'INSERT INTO personal_data (' . implode(',', $cols) . ') VALUES (' . $place . ') '
+             . 'ON DUPLICATE KEY UPDATE ' . $update;
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($personal));
     } else {


### PR DESCRIPTION
## Summary
- prevent cascading deletion of deposit crypto addresses

## Testing
- `php -l setter.php`
- `php -l getter.php`
- `php -l admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_687276638c3483269eb90b0ba06f5010