### PR TITLE
Fix upload area click loop

### DIFF
--- a/script.js
+++ b/script.js
@@ -938,7 +938,12 @@ function initializeUI() {
             $area.find('p').text('Cliquez pour modifier le fichier');
         };
 
-        $area.on('click', () => $input.trigger('click'));
+        $area.on('click', (e) => {
+            e.preventDefault();
+            $input.trigger('click');
+        });
+
+        $input.on('click', (e) => e.stopPropagation());
 
         $input.on('change', function () {
             if (this.files.length > 0) {


### PR DESCRIPTION
## Summary
- avoid bubbling when clicking upload areas

## Testing
- `php -l admin_getter.php`
- `php -l admin_login.php`
- `php -l admin_logout.php`
- `php -l admin_setter.php`
- `php -l admin_transactions_getter.php`
- `php -l get_wallets.php`
- `php -l getter.php`
- `php -l kyc_admin.php`
- `php -l kyc_upload.php`
- `php -l setter.php`
- `php -l user_login.php`
- `php -l user_transactions_getter.php`


------
https://chatgpt.com/codex/tasks/task_e_687448a29120832690713592c56f8ace