### PR TITLE
Add time period selector for admin stats

### DIFF
--- a/admin_getter.php
+++ b/admin_getter.php
@@ -46,8 +46,28 @@ if ((int)$admin['is_admin'] === 1) {
     $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$stmt = $pdo->prepare('SELECT * FROM personal_data WHERE linked_to_id = ?');
-$stmt->execute([$adminId]);
+$period = isset($_GET['period']) ? strtolower($_GET['period']) : 'all';
+$startDate = null;
+switch ($period) {
+    case 'daily':
+        $startDate = date('Y-m-d');
+        break;
+    case 'weekly':
+        $startDate = date('Y-m-d', strtotime('-6 days'));
+        break;
+    case 'monthly':
+        $startDate = date('Y-m-d', strtotime('-29 days'));
+        break;
+}
+
+$userSql = 'SELECT * FROM personal_data WHERE linked_to_id = ?';
+$userParams = [$adminId];
+if ($startDate) {
+    $userSql .= ' AND STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
+    $userParams[] = $startDate;
+}
+$stmt = $pdo->prepare($userSql);
+$stmt->execute($userParams);
 $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $stmt = $pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id = ? AND k.status = "pending"');
@@ -63,8 +83,13 @@ $successUsers = [];
 if ($userIds) {
     $placeholders = implode(',', array_fill(0, count($userIds), '?'));
     $sql = "SELECT user_id, amount FROM deposits WHERE status='complet' AND user_id IN ($placeholders)";
+    $params = $userIds;
+    if ($startDate) {
+        $sql .= " AND STR_TO_DATE(date, '%Y/%m/%d') >= STR_TO_DATE(?, '%Y-%m-%d')";
+        $params[] = $startDate;
+    }
     $stmt = $pdo->prepare($sql);
-    $stmt->execute($userIds);
+    $stmt->execute($params);
     foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
         $sumDeposits += (float)$row['amount'];
         $depositCount++;

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -153,6 +153,14 @@
                     
                     <!-- Home Section -->
                     <div id="home-section" class="content-section active">
+                        <div class="d-flex justify-content-end mb-2">
+                            <select id="statsPeriodSelect" class="form-select w-auto">
+                                <option value="daily">Journalier</option>
+                                <option value="weekly">Hebdomadaire</option>
+                                <option value="monthly">Mensuel</option>
+                                <option value="all" selected>Tout</option>
+                            </select>
+                        </div>
                         <div class="row mb-4">
                             <div class="col-md-3 mb-3">
                                 <div class="card stats-card">
@@ -866,6 +874,13 @@
                     if (targetSection === 'transactions') { TX_PAGE = 1; loadTransactions(); }
                 });
             });
+            const statsSelect = document.getElementById('statsPeriodSelect');
+            if (statsSelect) {
+                statsSelect.addEventListener('change', function() {
+                    STATS_PERIOD = this.value;
+                    loadAdminData();
+                });
+            }
             checkAuth();
             const pwdInput = document.getElementById('password');
             if (pwdInput) {
@@ -899,6 +914,7 @@
         let ADMIN_ID = null;
         let ADMIN_EMAIL = '';
         let IS_ADMIN = 0;
+        let STATS_PERIOD = 'all';
 
         // Minimal MD5 implementation used to hash passwords client-side
         function md5(str) {
@@ -1104,7 +1120,7 @@
 
         async function checkAuth() {
             try {
-                const res = await fetchWithAuth('admin_getter.php');
+                const res = await fetchWithAuth('admin_getter.php?period=' + encodeURIComponent(STATS_PERIOD));
                 if (!res.ok) throw new Error('unauthorized');
                 const data = await res.json();
                 if (data.admin_id) ADMIN_ID = data.admin_id;
@@ -1155,7 +1171,7 @@
 
         async function loadAdminData() {
             try {
-                const res = await fetchWithAuth('admin_getter.php');
+                const res = await fetchWithAuth('admin_getter.php?period=' + encodeURIComponent(STATS_PERIOD));
                 const data = await res.json();
                 if (data.admin_id) ADMIN_ID = data.admin_id;
                 if (data.email) ADMIN_EMAIL = data.email;


### PR DESCRIPTION
## Summary
- add period parameter to `admin_getter.php` to filter stats
- add dropdown on admin dashboard to choose daily/weekly/monthly/all
- send selected period when loading admin data

## Testing
- `php -l admin_getter.php`

------
https://chatgpt.com/codex/tasks/task_e_6879637621b083269f794c7f45dc8ce8