### PR TITLE
Add success modal for KYC upload

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1273,6 +1273,23 @@
           </tbody>
         </table>
       </div>
+</div>
+</div>
+</div>
+<!-- Modal: KYC Upload Success -->
+<div class="modal fade" id="kycSuccessModal" tabindex="-1" aria-labelledby="kycSuccessModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="kycSuccessModalLabel">Documents envoyés</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+      </div>
+      <div class="modal-body">
+        Vos documents ont été envoyés avec succès.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+      </div>
     </div>
   </div>
 </div>

--- a/script.js
+++ b/script.js
@@ -976,7 +976,7 @@ function initializeUI() {
         const result = await res.json();
         if (result.status === 'ok') {
             setKYCStatus('telechargerlesdocumentsdidentitestat', 2);
-            alert('Documents envoyés');
+            $('#kycSuccessModal').modal('show');
         } else {
             alert('Erreur lors de l\'envoi');
         }


### PR DESCRIPTION
## Summary
- show a Bootstrap modal confirming that KYC documents were uploaded
- add HTML for the success modal on the user dashboard

## Testing
- `php -l kyc_upload.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_687966c930ec8326877b574d9dff36b2