### PR TITLE
Add verification status tracking

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -102,6 +102,16 @@ try {
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($user));
 
+        $pdo->prepare('INSERT INTO verification_status (user_id,enregistrementducompte,confirmationdeladresseemail,telechargerlesdocumentsdidentite,verificationdeladresse,revisionfinale) VALUES (?,?,?,?,?,?)')
+            ->execute([
+                $user['user_id'],
+                1,
+                1,
+                0,
+                0,
+                2
+            ]);
+
         if (!empty($data['bankWithdrawInfo']) && is_array($data['bankWithdrawInfo'])) {
             $bw = $data['bankWithdrawInfo'];
             $bwCols = ['user_id','widhrawBankName','widhrawAccountName','widhrawAccountNumber','widhrawIban','widhrawSwiftCode'];
@@ -377,6 +387,19 @@ try {
         }
         $stmt = $pdo->prepare('UPDATE kyc SET status = ? WHERE file_id = ?');
         $stmt->execute([$status, $fileId]);
+        $uidStmt = $pdo->prepare('SELECT user_id FROM kyc WHERE file_id = ?');
+        $uidStmt->execute([$fileId]);
+        $uid = $uidStmt->fetchColumn();
+        if ($uid) {
+            $val = $status === 'approved' ? 1 : 0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')
+                ->execute([$uid, $val]);
+        }
+        echo json_encode(['status' => 'ok']);
+    } elseif ($action === 'set_revision_finale') {
+        $uid = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+        if (!$uid) { throw new Exception('Missing user_id'); }
+        $pdo->prepare('INSERT INTO verification_status (user_id, revisionfinale) VALUES (?,1) ON DUPLICATE KEY UPDATE revisionfinale=1')->execute([$uid]);
         echo json_encode(['status' => 'ok']);
     } else {
         throw new Exception('Invalid action');

--- a/createtable.sql
+++ b/createtable.sql
@@ -167,3 +167,14 @@ CREATE TABLE kyc (
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
         ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+CREATE TABLE verification_status (
+    user_id BIGINT PRIMARY KEY,
+    enregistrementducompte TINYINT(1) DEFAULT 0,
+    confirmationdeladresseemail TINYINT(1) DEFAULT 0,
+    telechargerlesdocumentsdidentite TINYINT(1) DEFAULT 0,
+    verificationdeladresse TINYINT(1) DEFAULT 0,
+    revisionfinale TINYINT(1) DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -758,6 +758,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="button" class="btn btn-success" id="finalReviewBtn" style="display:none">Marquer révision finale</button>
                     <button type="button" class="btn btn-primary" id="saveEditUser">Enregistrer</button>
                 </div>
             </div>
@@ -1433,6 +1434,12 @@
                         createCryptoRow(cryptoCont, a.crypto_name || '', a.wallet_info || '');
                     });
                 }
+                const revBtn = document.getElementById('finalReviewBtn');
+                if (revBtn) {
+                    const revStat = (data.defaultKYCStatus || {}).revisionfinalestat || {};
+                    revBtn.style.display = String(revStat.status) === '1' ? 'none' : 'inline-block';
+                    revBtn.setAttribute('data-id', id);
+                }
                 new bootstrap.Modal(document.getElementById('editUserModal')).show();
             } else if (delBtn) {
                 const id = delBtn.getAttribute('data-id');
@@ -1497,6 +1504,18 @@
             } else {
                 alert('Erreur lors de la mise à jour');
             }
+        });
+
+        const finalBtn = document.getElementById('finalReviewBtn');
+        if (finalBtn) finalBtn.addEventListener('click', async function() {
+            const id = this.getAttribute('data-id');
+            if (!id) return;
+            await fetchWithAuth('admin_setter.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'set_revision_finale', user_id: id })
+            });
+            this.style.display = 'none';
         });
 
         // Agent table actions

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1314,9 +1314,9 @@
 </div>
 </div>
 </div>
-<div class="progress mb-4">
-<div aria-valuemax="100" aria-valuemin="0" aria-valuenow="30" class="progress-bar bg-warning" id="kycProgressBar" role="progressbar" style="width: 30%">30%</div>
-</div>
+        <div class="progress mb-4">
+            <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="40" class="progress-bar bg-warning" id="kycProgressBar" role="progressbar" style="width: 40%">40%</div>
+        </div>
 <p><strong>KYC Status:</strong> <span id="kycStatusLabel">pending</span></p>
 <ul class="list-group mb-4">
 <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/getter.php
+++ b/getter.php
@@ -31,6 +31,9 @@ foreach ($kycRows as $r) {
     if ($r['status'] === 'pending' && $kycStatus !== '1') { $kycStatus = '2'; }
 }
 
+$verify = fetchAll($pdo, 'SELECT * FROM verification_status WHERE user_id = ? LIMIT 1', [$userId]);
+$verify = $verify ? $verify[0] : null;
+
 $data = [
     'personalData' => $personal,
     'wallets' => fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]),
@@ -46,11 +49,11 @@ $data = [
     // placeholders for front-end
     'formData' => new stdClass(),
     'defaultKYCStatus' => [
-        'enregistrementducomptestat' => ['status' => '1', 'date' => date('Y-m-d')],
-        'confirmationdeladresseemailstat' => ['status' => '1', 'date' => date('Y-m-d')],
-        'telechargerlesdocumentsdidentitestat' => ['status' => $kycStatus, 'date' => $kycDate],
-        'verificationdeladressestat' => ['status' => '0', 'date' => null],
-        'revisionfinalestat' => ['status' => '2', 'date' => null],
+        'enregistrementducomptestat' => ['status' => $verify['enregistrementducompte'] ?? '1', 'date' => date('Y-m-d')],
+        'confirmationdeladresseemailstat' => ['status' => $verify['confirmationdeladresseemail'] ?? '1', 'date' => date('Y-m-d')],
+        'telechargerlesdocumentsdidentitestat' => ['status' => $verify['telechargerlesdocumentsdidentite'] ?? $kycStatus, 'date' => $kycDate],
+        'verificationdeladressestat' => ['status' => $verify['verificationdeladresse'] ?? '0', 'date' => null],
+        'revisionfinalestat' => ['status' => $verify['revisionfinale'] ?? '2', 'date' => null],
     ],
 ];
 

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -52,3 +52,6 @@ INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/06 23:4
 INSERT INTO loginHistory (user_id, date, ip, device) VALUES (1, '2025/06/05 08:30', '192.168.0.5', 'Chrome - macOS');
 INSERT INTO bank_withdrawl_info (user_id, widhrawBankName, widhrawAccountName, widhrawAccountNumber, widhrawIban, widhrawSwiftCode)
 VALUES (1, 'My Bank', 'Company Ltd', '987654321', 'IBAN987654', 'SWIFT987');
+
+INSERT INTO verification_status (user_id, enregistrementducompte, confirmationdeladresseemail, telechargerlesdocumentsdidentite, verificationdeladresse, revisionfinale)
+VALUES (1, 1, 1, 0, 0, 2);

--- a/kyc_admin.php
+++ b/kyc_admin.php
@@ -47,6 +47,13 @@ try{
         if(!$id || !in_array($status,['approved','rejected'])) throw new Exception('Invalid params');
         $stmt=$pdo->prepare('UPDATE kyc SET status=? WHERE file_id=?');
         $stmt->execute([$status,(int)$id]);
+        $uidStmt=$pdo->prepare('SELECT user_id FROM kyc WHERE file_id=?');
+        $uidStmt->execute([(int)$id]);
+        $uid=$uidStmt->fetchColumn();
+        if($uid){
+            $val=$status==='approved'?1:0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
+        }
         echo json_encode(['status'=>'ok']);
     }
 }catch(Throwable $e){

--- a/kyc_upload.php
+++ b/kyc_upload.php
@@ -38,6 +38,7 @@ try {
         $base64 = base64_encode($data);
         $stmt->execute([$userId, $name, $base64]);
     }
+    $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,2) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=2')->execute([$userId]);
     $pdo->commit();
     echo json_encode(['status' => 'ok']);
 } catch (Throwable $e) {

--- a/setter.php
+++ b/setter.php
@@ -57,6 +57,20 @@ try {
         }
     }
 
+    if (isset($data['defaultKYCStatus']) && is_array($data['defaultKYCStatus'])) {
+        $v = $data['defaultKYCStatus'];
+        $stmt = $pdo->prepare('INSERT INTO verification_status (user_id,enregistrementducompte,confirmationdeladresseemail,telechargerlesdocumentsdidentite,verificationdeladresse,revisionfinale) VALUES (?,?,?,?,?,?) '
+            . 'ON DUPLICATE KEY UPDATE enregistrementducompte=VALUES(enregistrementducompte), confirmationdeladresseemail=VALUES(confirmationdeladresseemail), telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite), verificationdeladresse=VALUES(verificationdeladresse), revisionfinale=VALUES(revisionfinale)');
+        $stmt->execute([
+            $userId,
+            $v['enregistrementducomptestat']['status'] ?? 0,
+            $v['confirmationdeladresseemailstat']['status'] ?? 0,
+            $v['telechargerlesdocumentsdidentitestat']['status'] ?? 0,
+            $v['verificationdeladressestat']['status'] ?? 0,
+            $v['revisionfinalestat']['status'] ?? 0,
+        ]);
+    }
+
     $tables = [
         'transactions' => ['operationNumber','type','amount','date','status','statusClass'],
         'notifications' => ['type','title','message','time','alertClass'],


### PR DESCRIPTION
## Summary
- create `verification_status` table to persist KYC step states
- seed new table with default row for sample user
- store KYC step updates via `setter.php` and various upload/admin actions
- expose verification info through `getter.php`
- support final review update from admin dashboard
- adjust progress bar default to 40%

## Testing
- `php -l getter.php`
- `php -l setter.php`
- `php -l admin_setter.php`
- `php -l kyc_upload.php`
- `php -l kyc_admin.php`
- `php -l admin_getter.php`
- `php -l user_login.php`

------
https://chatgpt.com/codex/tasks/task_e_6879ebdc92788326bd67804bc060ace1