### PR TITLE
Fix memory usage in getter

### DIFF
--- a/getter.php
+++ b/getter.php
@@ -6,8 +6,10 @@ set_error_handler(function ($severity, $message, $file, $line) {
 
 try {
     $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo = new PDO($dsn, 'root', '', [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false
+    ]);
 
     $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
 


### PR DESCRIPTION
## Summary
- configure PDO to use unbuffered queries in `getter.php`

## Testing
- `php -l getter.php`


------
https://chatgpt.com/codex/tasks/task_e_6879f3d387ac8326be545f4e24a93321