### PR TITLE
Update initial KYC status display

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1321,33 +1321,33 @@
 <ul class="list-group mb-4">
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>
-<i class="fas fa-check-circle text-success me-2" id="enregistrementducompteicon"></i> Enregistrement du compte
+<i class="fas fa-clock text-warning me-2" id="enregistrementducompteicon"></i> Enregistrement du compte
                           </div>
-<span class="badge bg-success rounded-pill" id="enregistrementducomptestat">complet</span>
+<span class="badge bg-warning rounded-pill" id="enregistrementducomptestat">En cours</span>
 </li>
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>
-<i class="fas fa-check-circle text-success me-2" id="confirmationdeladresseemailicon"></i> Confirmation de l’adresse e-mail
+<i class="fas fa-clock text-warning me-2" id="confirmationdeladresseemailicon"></i> Confirmation de l’adresse e-mail
                           </div>
-<span class="badge bg-success rounded-pill" id="confirmationdeladresseemailstat">complet</span>
+<span class="badge bg-warning rounded-pill" id="confirmationdeladresseemailstat">En cours</span>
 </li>
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>
-<i class="fas fa-times-circle text-danger me-2" id="telechargerlesdocumentsdidentiteicon"></i> Télécharger les documents d’identité
+<i class="fas fa-clock text-warning me-2" id="telechargerlesdocumentsdidentiteicon"></i> Télécharger les documents d’identité
                           </div>
-<span class="badge bg-danger rounded-pill" id="telechargerlesdocumentsdidentitestat">Incomplet</span>
+<span class="badge bg-warning rounded-pill" id="telechargerlesdocumentsdidentitestat">En cours</span>
 </li>
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>
-<i class="fas fa-times-circle text-danger me-2" id="verificationdeladresseicon"></i> Vérification de l’adresse
+<i class="fas fa-clock text-warning me-2" id="verificationdeladresseicon"></i> Vérification de l’adresse
                           </div>
-<span class="badge bg-danger rounded-pill" id="verificationdeladressestat">Incomplet</span>
+<span class="badge bg-warning rounded-pill" id="verificationdeladressestat">En cours</span>
 </li>
 <li class="list-group-item d-flex justify-content-between align-items-center">
 <div>
-<i class="fas fa-times-circle text-danger me-2" id="revisionfinaleicon"></i> Révision finale
+<i class="fas fa-clock text-warning me-2" id="revisionfinaleicon"></i> Révision finale
                           </div>
-<span class="badge bg-secondary rounded-pill" id="revisionfinalestat">En cours</span>
+<span class="badge bg-warning rounded-pill" id="revisionfinalestat">En cours</span>
 </li>
 </ul>
 </div>

--- a/getter.php
+++ b/getter.php
@@ -51,10 +51,10 @@ $data = [
     // placeholders for front-end
     'formData' => new stdClass(),
     'defaultKYCStatus' => [
-        'enregistrementducomptestat' => ['status' => $verify['enregistrementducompte'] ?? '1', 'date' => date('Y-m-d')],
-        'confirmationdeladresseemailstat' => ['status' => $verify['confirmationdeladresseemail'] ?? '1', 'date' => date('Y-m-d')],
-        'telechargerlesdocumentsdidentitestat' => ['status' => $verify['telechargerlesdocumentsdidentite'] ?? $kycStatus, 'date' => $kycDate],
-        'verificationdeladressestat' => ['status' => $verify['verificationdeladresse'] ?? '0', 'date' => null],
+        'enregistrementducomptestat' => ['status' => $verify['enregistrementducompte'] ?? '2', 'date' => date('Y-m-d')],
+        'confirmationdeladresseemailstat' => ['status' => $verify['confirmationdeladresseemail'] ?? '2', 'date' => date('Y-m-d')],
+        'telechargerlesdocumentsdidentitestat' => ['status' => $verify['telechargerlesdocumentsdidentite'] ?? ($kycRows ? $kycStatus : '2'), 'date' => $kycDate],
+        'verificationdeladressestat' => ['status' => $verify['verificationdeladresse'] ?? '2', 'date' => null],
         'revisionfinalestat' => ['status' => $verify['revisionfinale'] ?? '2', 'date' => null],
     ],
 ];


### PR DESCRIPTION
## Summary
- show all verification steps as `En cours` when the page loads
- return default KYC steps as status `2` from the API

## Testing
- `php -l getter.php`

------
https://chatgpt.com/codex/tasks/task_e_687a080407548326a3e703859fcd012e