### PR TITLE
Fix login history insertion

### DIFF
--- a/user_login.php
+++ b/user_login.php
@@ -9,6 +9,15 @@ try {
     $pdo = new PDO($dsn, 'root', '');
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+    // Ensure the loginHistory table exists in case the schema was not loaded
+    $pdo->exec("CREATE TABLE IF NOT EXISTS loginHistory (
+        id INTEGER PRIMARY KEY AUTO_INCREMENT,
+        user_id BIGINT,
+        date TEXT,
+        ip TEXT,
+        device TEXT
+    )");
+
     $email = $_POST['email'] ?? '';
     $password = $_POST['password'] ?? '';
 


### PR DESCRIPTION
## Summary
- ensure the loginHistory table exists before inserting login events

## Testing
- `for f in *.php; do echo "Linting $f"; php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_687ac3f468688326b85f5e9680f733c6