### PR TITLE
Add manual stop feature and cron script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ Use `admin_login.php` to sign in. POST `email` and `password`; a successful logi
 ## User Login
 
 `dashbord_user.html` now includes a login form. Submit your email and password to `user_login.php`; on success the script stores your `user_id` in `localStorage` and loads the dashboard for that account. Each successful login is also recorded in the `loginHistory` table along with the IP address and device used.
+
+## Automated trade closing
+
+Open trades can be finalized automatically even when users are offline. The `cron_trading.php` script checks all orders with the status `En cours`, fetches the latest price from Binance and updates the order with the resulting profit or loss. To keep trading positions active, schedule the script with cron for example:
+
+```cron
+* * * * * php /path/to/cron_trading.php
+```
+
+This will close any open trades once per minute using the current market price.

--- a/cron_trading.php
+++ b/cron_trading.php
@@ -1,0 +1,23 @@
+<?php
+// Simple cron job to finalize open trades using current market price
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+$orders = $pdo->query("SELECT * FROM tradingHistory WHERE statut='En cours'")->fetchAll(PDO::FETCH_ASSOC);
+foreach ($orders as $o) {
+    $symbol = str_replace('USD', 'USDT', str_replace('/', '', $o['paireDevises']));
+    $data = @json_decode(file_get_contents("https://api.binance.com/api/v3/ticker/price?symbol=$symbol"), true);
+    if (!isset($data['price'])) continue;
+    $exit = (float)$data['price'];
+    $entry = (float)$o['prix'];
+    $qty = (float)$o['montant'];
+    $profit = ($o['type'] === 'Acheter') ? ($exit - $entry) * $qty : ($entry - $exit) * $qty;
+    $profitClass = $profit >= 0 ? 'text-success' : 'text-danger';
+    $pdo->prepare("UPDATE tradingHistory SET profitPerte=?, profitClass=?, statut='complet', statutClass='bg-success' WHERE id=?")
+        ->execute([$profit, $profitClass, $o['id']]);
+    $pdo->prepare("UPDATE transactions SET status='complet', statusClass='bg-success' WHERE operationNumber=?")
+        ->execute([$o['operationNumber']]);
+    $invested = $entry * $qty;
+    $pdo->prepare("UPDATE personal_data SET balance = balance + ? WHERE user_id=?")
+        ->execute([$invested + $profit, $o['user_id']]);
+}

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -341,6 +341,7 @@
 <th>Le prix</th>
 <th>Statut</th>
 <th>Profit/Perte</th>
+<th>Stop</th>
 </tr>
 </thead>
 <tbody id="tradingHistory">

--- a/script.js
+++ b/script.js
@@ -1269,10 +1269,11 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(trade.profitClass || '')}">${trade.profitPerte==null?'-':formatDollar(trade.profitPerte)}</td>
+                        <td>${trade.statut==='En cours'?`<button class="btn btn-sm btn-danger stop-trade" data-op="${escapeHtml(trade.operationNumber)}"><i class="fas fa-stop"></i></button>`:'-'}</td>
                     </tr>`);
             });
         } else {
-            $tbodyTrading.html('<tr><td colspan="8" class="text-center">Aucune donnée disponible</td></tr>');
+            $tbodyTrading.html('<tr><td colspan="9" class="text-center">Aucune donnée disponible</td></tr>');
         }
     }
 
@@ -1591,6 +1592,14 @@ function initializeUI() {
     } else {
         $loginHistoryBody.html('<tr><td colspan="3" class="text-center">Aucune donnée disponible</td></tr>');
     }
+
+    $('#tradingHistory').on('click', '.stop-trade', function() {
+        const op = $(this).data('op');
+        const trade = (dashboardData.tradingHistory || []).find(t => t.operationNumber === op);
+        if (trade && trade.statut === 'En cours') {
+            finalizeOrder(trade, currentPrice);
+        }
+    });
 
     $('#transactionsPagination').on('click', 'a', function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add new `Stop` column to trading history
- allow users to finalize an open trade at the current price
- provide a PHP cron job for closing open trades automatically
- document how to schedule the cron job

## Testing
- `php -l cron_trading.php`
- `ls *.php | xargs -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687acb4bbe808326ab69e2652eceb273