### PR TITLE
Add limit order endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ the `trades` table. Run it periodically just like the cron script:
 ```cron
 * * * * * php /path/to/order_processor.php
 ```
+To place a pending limit order use `limit_order.php`. POST a JSON body containing `user_id`, `pair`, `quantity`, `side` and `target_price`. The script verifies the account balance and stores the order with status `open`. Once the market price reaches the target, `order_processor.php` will execute the trade and update wallets.
 
 ### Order types and stop loss
 

--- a/limit_order.php
+++ b/limit_order.php
@@ -1,0 +1,67 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    $input = file_get_contents('php://input');
+    $data = json_decode($input, true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Invalid JSON']);
+        exit;
+    }
+
+    $userId = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+    $pair = $data['pair'] ?? '';
+    $quantity = isset($data['quantity']) ? (float)$data['quantity'] : 0.0;
+    $side = strtolower($data['side'] ?? 'buy');
+    $target = isset($data['target_price']) ? (float)$data['target_price'] : 0.0;
+
+    if (!$userId || !$pair || $quantity <= 0 || $target <= 0 || !in_array($side, ['buy','sell'])) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Missing parameters']);
+        exit;
+    }
+
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+    [$base, $quote] = explode('/', strtoupper($pair));
+
+    if ($side === 'buy') {
+        $total = $target * $quantity;
+        $stmt = $pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+        $stmt->execute([$userId]);
+        $balance = $stmt->fetchColumn();
+        if ($balance === false || $balance < $total) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => 'رصيد غير كافٍ']);
+            exit;
+        }
+    } else { // sell
+        $stmt = $pdo->prepare('SELECT amount FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
+        $stmt->execute([$userId, $base]);
+        $bal = $stmt->fetchColumn();
+        if ($bal === false || $bal < $quantity) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => 'رصيد غير كافٍ']);
+            exit;
+        }
+    }
+    $stmt = $pdo->prepare("INSERT INTO orders (user_id,pair,type,side,quantity,target_price,status) VALUES (?,?,?,?,?,?,?)");
+    $stmt->execute([$userId, $pair, 'limit', $side, $quantity, $target, 'open']);
+
+    echo json_encode([
+        'status' => 'ok',
+        'message' => "تم إنشاء أمر محدد بقيمة {$quantity} {$base} على سعر {$target} {$quote}",
+        'order_id' => $pdo->lastInsertId()
+    ]);
+} catch (Throwable $e) {
+    if (isset($pdo) && $pdo->inTransaction()) $pdo->rollBack();
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- implement `limit_order.php` to register limit orders
- document how to place limit orders in README

## Testing
- `php -l limit_order.php`
- `php -l market_order.php`
- `php -l order_processor.php`


------
https://chatgpt.com/codex/tasks/task_e_687ee92da5a08326a65dff8d24098956