### PR TITLE
Update order processing to debit account balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,13 @@ Example pseudo-code for order execution:
 $price = getLivePrice($pair);
 $total = $price * $quantity;
 if ($side === 'buy') {
-    deductFromWallet($userId, 'USDT', $total);
+    // deduct dollars from the user's account balance
+    deductFromAccount($userId, $total);
     addOrUpdateWallet($userId, $base, $quantity, 'local address');
 } else {
     deductFromWallet($userId, $base, $quantity);
-    addOrUpdateWallet($userId, 'USDT', $total, 'local address');
+    // credit dollars back to the account
+    addToAccount($userId, $total);
 }
 recordTrade($userId, $pair, $side, $quantity, $price);
 

--- a/order_processor.php
+++ b/order_processor.php
@@ -30,6 +30,29 @@ function addToWallet(PDO $pdo, int $userId, string $currency, float $amount): vo
 }
 
 /**
+ * Deduct dollars from the user's account balance.
+ */
+function deductFromAccount(PDO $pdo, int $userId, float $amount): bool {
+    $stmt = $pdo->prepare('SELECT balance FROM personal_data WHERE user_id=?');
+    $stmt->execute([$userId]);
+    $bal = $stmt->fetchColumn();
+    if ($bal === false || $bal < $amount) {
+        return false;
+    }
+    $stmt = $pdo->prepare('UPDATE personal_data SET balance = balance - ? WHERE user_id=?');
+    $stmt->execute([$amount, $userId]);
+    return true;
+}
+
+/**
+ * Credit dollars to the user's account balance.
+ */
+function addToAccount(PDO $pdo, int $userId, float $amount): void {
+    $pdo->prepare('UPDATE personal_data SET balance = balance + ? WHERE user_id=?')
+        ->execute([$amount, $userId]);
+}
+
+/**
  * Decrease amount of a currency in user's wallet.
  */
 function deductFromWallet(PDO $pdo, int $userId, string $currency, float $amount): bool {
@@ -74,7 +97,7 @@ function executeOrder(PDO $pdo, array $order, float $price): void {
     $total = $price * $qty;
 
     if ($order['side'] === 'buy') {
-        if (!deductFromWallet($pdo, $order['user_id'], $quote, $total)) {
+        if (!deductFromAccount($pdo, $order['user_id'], $total)) {
             // insufficient balance, cancel order
             $pdo->prepare('UPDATE orders SET status="cancelled" WHERE id=?')->execute([$order['id']]);
             return;
@@ -85,7 +108,7 @@ function executeOrder(PDO $pdo, array $order, float $price): void {
             $pdo->prepare('UPDATE orders SET status="cancelled" WHERE id=?')->execute([$order['id']]);
             return;
         }
-        addToWallet($pdo, $order['user_id'], $quote, $total);
+        addToAccount($pdo, $order['user_id'], $total);
     }
     recordTrade($pdo, $order, $price);
 }


### PR DESCRIPTION
## Summary
- withdraw USD balance when executing any buy order
- deposit proceeds from sells back to the account
- document new functions in the README

## Testing
- `php` was unavailable so syntax check couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_687f00ded1e48326a73d9ebc587e74a3