### PR TITLE
Fix wallet amount persistence

### DIFF
--- a/setter.php
+++ b/setter.php
@@ -44,7 +44,10 @@ try {
 
     $pdo->prepare('DELETE FROM wallets WHERE user_id = ?')->execute([$userId]);
     if ($wallets) {
-        $stmt = $pdo->prepare('INSERT INTO wallets (id,user_id,currency,network,address,label) VALUES (?,?,?,?,?,?)');
+        $stmt = $pdo->prepare(
+            'INSERT INTO wallets (id,user_id,currency,network,address,label,amount) '
+            . 'VALUES (?,?,?,?,?,?,?)'
+        );
         foreach ($wallets as $w) {
             $stmt->execute([
                 $w['id'] ?? null,
@@ -52,7 +55,8 @@ try {
                 $w['currency'] ?? '',
                 $w['network'] ?? '',
                 $w['address'] ?? '',
-                $w['label'] ?? ''
+                $w['label'] ?? '',
+                isset($w['amount']) ? $w['amount'] : 0
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- update `setter.php` to keep wallet amounts when saving dashboard data

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_687f05d447c48326b246574e27e994a9