### PR TITLE
Update balance after market buy

### DIFF
--- a/market_order.php
+++ b/market_order.php
@@ -69,6 +69,7 @@ try {
 
     $stmt = $pdo->prepare('UPDATE personal_data SET balance = balance - ? WHERE user_id = ?');
     $stmt->execute([$total, $userId]);
+    $newBalance = $balance - $total;
 
     addToWallet($pdo, $userId, $base, $quantity);
 
@@ -82,7 +83,8 @@ try {
     echo json_encode([
         'status' => 'ok',
         'message' => "تم شراء {$quantity} {$base} بسعر السوق مقابل {$total} {$quote}",
-        'price' => $price
+        'price' => $price,
+        'new_balance' => $newBalance
     ]);
 } catch (Throwable $e) {
     if (isset($pdo) && $pdo->inTransaction()) $pdo->rollBack();

--- a/script.js
+++ b/script.js
@@ -1550,6 +1550,9 @@ function initializeUI() {
                 if (resp.price) {
                     price = parseFloat(resp.price);
                 }
+                if (resp.new_balance !== undefined) {
+                    dashboardData.personalData.balance = parseFloat(resp.new_balance);
+                }
                 if (resp.message) alert(resp.message);
             } catch (err) {
                 alert(err.message || 'Erreur de trading');
@@ -1563,7 +1566,9 @@ function initializeUI() {
 
         let newBalance = parseDollar(dashboardData.personalData.balance);
         if (orderType === 'market') {
-            if (isBuy) {
+            if (resp && resp.new_balance !== undefined) {
+                newBalance = parseFloat(resp.new_balance);
+            } else if (isBuy) {
                 newBalance -= amount * price;
             } else {
                 newBalance += amount * price;


### PR DESCRIPTION
## Summary
- when executing a market order, return the updated account balance
- show the new balance in the dashboard after a buy

## Testing
- `php -l market_order.php`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_687f07cf46308326b8a0446af965d4ec