### PR TITLE
Implement profile picture uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ crypto addresses with a `BIGINT` `id` so each entry keeps the unique identifier
 generated in JavaScript with `Date.now()`. User accounts use the same approach:
 the `personal_data.user_id` column is also a `BIGINT` so IDs created with
 `Date.now()` are inserted without overflowing.
+User profile photos can be uploaded via `profile_pic_upload.php`. This endpoint
+accepts a `user_id` and image file and stores the photo as base64 in the new
+`profile_pic` column of `personal_data`.
 
 All tables now use the **InnoDB** storage engine and any `AUTO_INCREMENT`
 columns have been widened to `BIGINT` to prevent errors when new rows are
@@ -31,7 +34,8 @@ bank coordinates shown on the deposit screen and each user has at most one
 record. These deposit details are filled in by an administrator when creating or
 editing a user. The admin dashboard's create and edit user modals now include
 input fields for these coordinates so they can be entered or updated alongside
-other personal data.
+other personal data. The `personal_data` table also has a `profile_pic` column
+where the user's profile image is stored as a base64 string.
 
 An additional table `admins_agents` stores admin and agent accounts. Each row
 contains an email, hashed password and an `is_admin` flag, plus a `created_by`

--- a/createtable.sql
+++ b/createtable.sql
@@ -38,6 +38,7 @@ CREATE TABLE personal_data (
     userIban TEXT,
     userSwiftCode TEXT,
     note TEXT,
+    profile_pic MEDIUMTEXT,
     linked_to_id INTEGER
 ) ENGINE=InnoDB;
 

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1170,7 +1170,7 @@
 </div>
 <div class="modal-footer">
 <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Annuler</button>
-<button class="btn btn-primary" type="button">Enregistrer les modifications</button>
+<button class="btn btn-primary" id="saveProfilePicBtn" type="button">Enregistrer les modifications</button>
 </div>
 </div>
 </div>

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -9,7 +9,7 @@ INSERT INTO personal_data VALUES (
 '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000',
 '2025-06-11', 'ca', '2025-01-01',
 'Bank of Earth', 'Ahmed Kouraychi',
-'ACC123456', 'IBAN123456', 'SWIFT123', '', 1
+'ACC123456', 'IBAN123456', 'SWIFT123', '', '', 1
 );
 
 INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES

--- a/profile_pic_upload.php
+++ b/profile_pic_upload.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
+try {
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'root', '');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $userId = $_POST['user_id'] ?? '';
+    if ($userId === '') {
+        throw new Exception('Missing user_id');
+    }
+    if (!isset($_FILES['file'])) {
+        throw new Exception('No file uploaded');
+    }
+    $file = $_FILES['file'];
+    if (($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+        throw new Exception('Upload error: ' . ($file['error'] ?? 0));
+    }
+    if (!is_uploaded_file($file['tmp_name'])) {
+        throw new Exception('Invalid upload');
+    }
+    $data = file_get_contents($file['tmp_name']);
+    $base64 = base64_encode($data);
+    $stmt = $pdo->prepare('UPDATE personal_data SET profile_pic=? WHERE user_id=?');
+    $stmt->execute([$base64, $userId]);
+    echo json_encode(['status' => 'ok', 'data' => $base64]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}
+?>

--- a/script.js
+++ b/script.js
@@ -617,6 +617,9 @@ function initializeUI() {
     const nameValInit = dashboardData.personalData.fullName || '';
     $('#fullNameHeader, #nameincompte').text(nameValInit);
     $('#firstname').text(nameValInit.split(' ')[0] || nameValInit);
+    if (dashboardData.personalData.profile_pic) {
+        $('.Profil-img').attr('src', 'data:image/jpeg;base64,' + dashboardData.personalData.profile_pic);
+    }
     const createdAt = dashboardData.personalData.created_at;
     if (createdAt) {
         const dt = new Date(createdAt);
@@ -994,6 +997,25 @@ function initializeUI() {
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 </div>`);
+        } else if (this.id === 'changeProfilePicForm') {
+            const file = $('#ProfilPicture')[0]?.files[0];
+            if (!file) return;
+            const fd = new FormData();
+            fd.append('user_id', userId);
+            fd.append('file', file, file.name);
+            fetch('profile_pic_upload.php', { method: 'POST', body: fd })
+                .then(r => r.json())
+                .then(res => {
+                    if (res.status === 'ok') {
+                        dashboardData.personalData.profile_pic = res.data;
+                        $('.Profil-img').attr('src', 'data:image/jpeg;base64,' + res.data);
+                        $('#changeProfilePicModal').modal('hide');
+                        saveDashboardData();
+                    } else {
+                        alert('Erreur lors du téléchargement');
+                    }
+                })
+                .catch(err => alert(err.message || 'Erreur'));
 
         }
     });


### PR DESCRIPTION
## Summary
- store user profile pics in `personal_data.profile_pic`
- add upload endpoint `profile_pic_upload.php`
- hook profile picture modal to new endpoint
- display stored profile picture on dashboard
- document profile picture column and endpoint

## Testing
- `php -l kyc_upload.php`
- `php -l profile_pic_upload.php`
- `php -l getter.php`
- `php -l setter.php`

------
https://chatgpt.com/codex/tasks/task_e_6882f9de7e0c8332928480b6acbd1391