### PR TITLE
Add KYC approval notifications

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -394,6 +394,18 @@ try {
             $val = $status === 'approved' ? 1 : 0;
             $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')
                 ->execute([$uid, $val]);
+            if ($status === 'approved') {
+                $timeAgo = formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+                $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
+                    ->execute([
+                        $uid,
+                        'kyc',
+                        'Vérification approuvée',
+                        "Votre vérification d'identité a été approuvée.",
+                        $timeAgo,
+                        'alert-success'
+                    ]);
+            }
         }
         echo json_encode(['status' => 'ok']);
     } elseif ($action === 'set_revision_finale') {

--- a/kyc_admin.php
+++ b/kyc_admin.php
@@ -5,6 +5,19 @@ try{
     $dsn='mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
     $pdo=new PDO($dsn,'root','');
     $pdo->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
+
+    function formatTimeAgoFromDate($dateStr){
+        $ts=strtotime($dateStr);
+        if(!$ts) return '';
+        $diff=time()-$ts;
+        if($diff<60) return "À l'instant";
+        $mins=floor($diff/60);
+        if($mins<60) return 'Il y a '.$mins.' minute'.($mins>1?'s':'');
+        $hours=floor($diff/3600);
+        if($hours<24) return 'Il y a '.$hours.' heure'.($hours>1?'s':'');
+        $days=floor($diff/86400);
+        return 'Il y a '.$days.' jour'.($days>1?'s':'');
+    }
     session_start();
     $adminId=$_SESSION['admin_id']??null;
     if(!$adminId){
@@ -53,6 +66,18 @@ try{
         if($uid){
             $val=$status==='approved'?1:0;
             $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
+            if($status==='approved'){
+                $timeAgo=formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+                $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
+                    ->execute([
+                        $uid,
+                        'kyc',
+                        'Vérification approuvée',
+                        "Votre vérification d'identité a été approuvée.",
+                        $timeAgo,
+                        'alert-success'
+                    ]);
+            }
         }
         echo json_encode(['status'=>'ok']);
     }


### PR DESCRIPTION
## Summary
- notify users when their KYC is approved
- reuse timeAgo helper in `kyc_admin.php`

## Testing
- `php -l kyc_admin.php`
- `php -l admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_6883036d73d48332839842d2a44fec50