### PR TITLE
Add admin notification for system update

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -379,6 +379,24 @@ try {
         $pdo->rollBack();
         throw $e;
     }
+    } elseif ($action === 'broadcast_update') {
+        $date = $data['date'] ?? '';
+        if (!$date) { throw new Exception('Missing date'); }
+        $stmt = $pdo->query('SELECT user_id FROM personal_data');
+        $userIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $timeAgo = formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+        $insert = $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)');
+        foreach ($userIds as $uid) {
+            $insert->execute([
+                (int)$uid,
+                'info',
+                'Mise à jour du système',
+                "Le système sera mis à jour le $date.",
+                $timeAgo,
+                'alert-info'
+            ]);
+        }
+        echo json_encode(['status' => 'ok']);
     } elseif ($action === 'update_kyc') {
         $fileId = isset($data['file_id']) ? (int)$data['file_id'] : 0;
         $status = $data['status'] ?? '';

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -236,13 +236,29 @@
                                             </button>
                                         </div>
                                     </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row mt-4">
+                    <div class="col-md-12">
+                        <div class="card">
+                            <div class="card-header">
+                                <h5 class="mb-0">Notifier les utilisateurs</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="input-group">
+                                    <span class="input-group-text">Date de mise à jour</span>
+                                    <input type="date" class="form-control" id="sysUpdateDate">
+                                    <button class="btn btn-primary" id="sendUpdateNotification">Envoyer</button>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
-                    <!-- Users Section -->
-                    <div id="users-section" class="content-section">
+                </div>
+            </div>
+
+            <!-- Users Section -->
+            <div id="users-section" class="content-section">
                         <div class="d-flex justify-content-between align-items-center mb-4">
                             <h3>Gestion des Utilisateurs</h3>
                             <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createUserModal">
@@ -1875,6 +1891,32 @@
                 loadKYCRequests();
             }
             bootstrap.Modal.getInstance(document.getElementById('kycModal')).hide();
+        });
+
+        const notifyBtn = document.getElementById('sendUpdateNotification');
+        if(notifyBtn) notifyBtn.addEventListener('click', async function(){
+            const date = document.getElementById('sysUpdateDate').value;
+            if(!date){
+                alert('Veuillez choisir une date');
+                return;
+            }
+            try {
+                const res = await fetchWithAuth('admin_setter.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'broadcast_update', date: date })
+                });
+                const result = await res.json();
+                if(result.status === 'ok'){
+                    alert('Notification envoyée');
+                    document.getElementById('sysUpdateDate').value = '';
+                } else {
+                    alert(result.message || 'Erreur');
+                }
+            } catch(err){
+                console.error('Notification error', err);
+                alert('Erreur');
+            }
         });
 
         const showAllBtn = document.getElementById('showAllDocsBtn');


### PR DESCRIPTION
## Summary
- allow admins to broadcast a system update notice
- add maintenance notification card on the admin home page
- wire up button to send notification to all users

## Testing
- `php -l admin_setter.php`

------
https://chatgpt.com/codex/tasks/task_e_68841ecee7648332a9429d773299d8f3