### PR TITLE
Fix undefined variable in market order

### DIFF
--- a/market_order.php
+++ b/market_order.php
@@ -81,7 +81,6 @@ try {
 
     $total = $price * $quantity;
 
-    $stmt->execute([$userId, $pair, $side, $quantity, $price, $total]);
     $pdo->beginTransaction();
 
     if ($side === 'buy') {


### PR DESCRIPTION
## Summary
- remove stray `$stmt->execute()` call in `market_order.php`

## Testing
- `php -l market_order.php`
- `find . -name '*.php' -maxdepth 1 -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68846c7bffb4833289459601066b2700