### PR TITLE
Display currency codes in wallet balances

### DIFF
--- a/script.js
+++ b/script.js
@@ -260,7 +260,7 @@ function renderWalletTable(wallets = dashboardData.personalData.wallets || []) {
                 <td>${escapeHtml(currencyNames[w.currency] || w.currency)}</td>
                 <td>${escapeHtml(w.network)}</td>
                 <td class="wallet-address">${escapeHtml(w.address || '---')}</td>
-                <td>${formatCrypto(w.amount)}</td>
+                <td>${formatCrypto(w.amount)} ${escapeHtml((w.currency || '').toUpperCase())}</td>
                 <td>
                     <button class="btn btn-sm btn-outline-primary me-1 wallet-edit" data-id="${escapeHtml(w.id)}"><i class="fas fa-edit"></i></button>
                     <button class="btn btn-sm btn-outline-danger wallet-delete" data-id="${escapeHtml(w.id)}"><i class="fas fa-trash"></i></button>


### PR DESCRIPTION
## Summary
- show the currency code next to each wallet balance in the user dashboard

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688473e5a73c8332b1cf91343da34a4c