### PR TITLE
Fix trading amount display

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ removes the wallet entirely. Edits and deletions are sent to
 data. The wallet table on the user dashboard now also displays the current
 balance for each address.
 
+The trading history table was updated as well. Amounts are shown with the
+traded coin symbol instead of dollars, e.g. `100 XRP`.
+
 ## Admin dashboard
 
 `insertdata.sql` seeds a default administrator account (`admin@scampia.io`) with

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1440,7 +1440,8 @@
                 tradeBody.innerHTML = '';
                 (data.tradingHistory || []).slice(0,10).forEach(t => {
                     const profit = t.profitPerte == null ? '-' : formatDollar(t.profitPerte);
-                    tradeBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(t.temps)}</td><td>${escapeHtml(t.paireDevises)}</td><td><span class="badge ${escapeHtml(t.statutTypeClass)}">${escapeHtml(t.type)}</span></td><td>${formatDollar(t.montant)}</td><td>${formatDollar(t.prix)}</td><td><span class="badge ${escapeHtml(t.statutClass)}">${escapeHtml(t.statut)}</span></td><td class="${escapeHtml(t.profitClass || '')}">${profit}</td></tr>`);
+                    const baseCoin = (t.paireDevises || '').split('/')[0];
+                    tradeBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(t.temps)}</td><td>${escapeHtml(t.paireDevises)}</td><td><span class="badge ${escapeHtml(t.statutTypeClass)}">${escapeHtml(t.type)}</span></td><td>${formatCrypto(t.montant)} ${escapeHtml(baseCoin)}</td><td>${formatDollar(t.prix)}</td><td><span class="badge ${escapeHtml(t.statutClass)}">${escapeHtml(t.statut)}</span></td><td class="${escapeHtml(t.profitClass || '')}">${profit}</td></tr>`);
                 });
                 if (!tradeBody.innerHTML) tradeBody.innerHTML = '<tr><td colspan="7" class="text-center">Aucune donnée</td></tr>';
                 new bootstrap.Modal(document.getElementById('viewUserModal')).show();

--- a/script.js
+++ b/script.js
@@ -1319,7 +1319,7 @@ function initializeUI() {
                         <td>${escapeHtml(trade.temps)}</td>
                         <td>${escapeHtml(trade.paireDevises)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutTypeClass)}">${escapeHtml(trade.type)}</span></td>
-                        <td>${formatDollar(trade.montant)}</td>
+                        <td>${formatCrypto(trade.montant)} ${escapeHtml((trade.paireDevises||'').split('/')[0])}</td>
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(trade.profitClass || '')}">${trade.profitPerte==null?'-':formatDollar(trade.profitPerte)}</td>


### PR DESCRIPTION
## Summary
- show the traded coin symbol instead of `$` for each amount in trading history
- update admin dashboard trade table accordingly
- document the change in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_688477faa1d083328a2cd977372149c9