### PR TITLE
Add config.php for DB settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ This project uses small PHP helpers (`getter.php` and `setter.php`) to read and 
 ## Database setup
 
 1. Make sure the PHP MySQL PDO extension is installed and a MySQL server is running.
-2. Create a database named `coin_db` and load the schema and sample data:
+2. Create a database named `admin_coindb` and load the schema and sample data:
    ```sh
-   mysql -u root coin_db < createtable.sql
-   mysql -u root coin_db < insertdata.sql
+   mysql -u admin_coin admin_coindb < createtable.sql
+   mysql -u admin_coin admin_coindb < insertdata.sql
    ```
-3. The PHP scripts connect to `coin_db` on `localhost` using the `root` user with an empty password. Update the connection settings in `getter.php` and `setter.php` if your environment differs.
+3. Database credentials are stored in `config.php`. The default configuration uses `localhost` with the `admin_coin` user and password `Perfect.41`.
 
 The dashboard pages (`dashbord_user.html` and `script.js`) request data from `getter.php` and send updates to `setter.php`.
 `script.js` now fetches wallet addresses from `get_wallets.php`, which returns `SELECT * FROM wallets WHERE user_id = ?` in JSON. The `wallets` table stores

--- a/admin_getter.php
+++ b/admin_getter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $adminId = null;

--- a/admin_login.php
+++ b/admin_login.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $email = $_POST['email'] ?? '';

--- a/admin_setter.php
+++ b/admin_setter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     function formatTimeAgoFromDate($dateStr) {

--- a/admin_transactions_getter.php
+++ b/admin_transactions_getter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $adminId = null;

--- a/advanced_order.php
+++ b/advanced_order.php
@@ -47,8 +47,8 @@ try {
         exit;
     }
 
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
     function getLivePrice(string $pair): float {
         $symbol = str_replace('/', '', strtoupper($pair));

--- a/config.php
+++ b/config.php
@@ -1,0 +1,4 @@
+<?php
+$dsn = 'mysql:host=localhost;dbname=admin_coindb;charset=utf8mb4';
+$dbUser = 'admin_coin';
+$dbPass = 'Perfect.41';

--- a/cron_trading.php
+++ b/cron_trading.php
@@ -1,7 +1,7 @@
 <?php
 // Simple cron job to finalize open trades using current market price
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+require __DIR__ . '/config.php';
+$pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
 $orders = $pdo->query("SELECT * FROM tradingHistory WHERE statut='En cours'")->fetchAll(PDO::FETCH_ASSOC);
 foreach ($orders as $o) {

--- a/get_wallets.php
+++ b/get_wallets.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/getter.php
+++ b/getter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '', [
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false
     ]);

--- a/kyc_admin.php
+++ b/kyc_admin.php
@@ -2,8 +2,8 @@
 header('Content-Type: application/json');
 set_error_handler(function($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
 try{
-    $dsn='mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo=new PDO($dsn,'root','');
+    require __DIR__ . '/config.php';
+    $pdo=new PDO($dsn,$dbUser,$dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
 
     function formatTimeAgoFromDate($dateStr){

--- a/kyc_upload.php
+++ b/kyc_upload.php
@@ -2,8 +2,8 @@
 header('Content-Type: application/json');
 set_error_handler(function ($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $userId = $_POST['user_id'] ?? '';

--- a/limit_order.php
+++ b/limit_order.php
@@ -25,8 +25,8 @@ try {
         exit;
     }
 
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
     [$base, $quote] = explode('/', strtoupper($pair));
 

--- a/market_order.php
+++ b/market_order.php
@@ -24,8 +24,8 @@ try {
         exit;
     }
 
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
     function getLivePrice(string $pair): float {
         $symbol = str_replace('/', '', strtoupper($pair));

--- a/order_processor.php
+++ b/order_processor.php
@@ -2,8 +2,8 @@
 // Basic order processing script using orders, wallets and trades tables
 // Run periodically (e.g. via cron) to execute open orders based on market prices
 
-$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-$pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+require __DIR__ . '/config.php';
+$pdo = new PDO($dsn, $dbUser, $dbPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
 /**
  * Fetch live price for a trading pair using Binance.

--- a/profile_pic_upload.php
+++ b/profile_pic_upload.php
@@ -2,8 +2,8 @@
 header('Content-Type: application/json');
 set_error_handler(function($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $userId = $_POST['user_id'] ?? '';

--- a/setter.php
+++ b/setter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $input = file_get_contents('php://input');

--- a/user_login.php
+++ b/user_login.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     // Ensure the loginHistory table exists in case the schema was not loaded

--- a/user_transactions_getter.php
+++ b/user_transactions_getter.php
@@ -5,8 +5,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
-    $pdo = new PDO($dsn, 'root', '');
+    require __DIR__ . '/config.php';
+    $pdo = new PDO($dsn, $dbUser, $dbPass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;


### PR DESCRIPTION
## Summary
- centralize DB credentials in `config.php`
- load `config.php` in all PHP scripts
- update README with new database name and config usage

## Testing
- `php -l admin_getter.php`
- `php -l admin_login.php`
- `php -l admin_setter.php`
- `php -l admin_transactions_getter.php`
- `php -l advanced_order.php`
- `php -l cron_trading.php`
- `php -l get_wallets.php`
- `php -l getter.php`
- `php -l kyc_admin.php`
- `php -l kyc_upload.php`
- `php -l limit_order.php`
- `php -l market_order.php`
- `php -l order_processor.php`
- `php -l profile_pic_upload.php`
- `php -l setter.php`
- `php -l user_login.php`
- `php -l user_transactions_getter.php`
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_6885672fcca0833297aff10251234c15