### PR TITLE
Fix unique email index

### DIFF
--- a/createtable.sql
+++ b/createtable.sql
@@ -1,6 +1,6 @@
 CREATE TABLE admins_agents (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    email TEXT NOT NULL,
+    email VARCHAR(255) NOT NULL,
     password TEXT NOT NULL,
     is_admin TINYINT(1) NOT NULL,
     created_by INTEGER NULL,


### PR DESCRIPTION
## Summary
- ensure `admins_agents.email` is indexable by changing its type to `VARCHAR(255)`

## Testing
- `apt-get update`
- `apt-get install -y mysql-client`


------
https://chatgpt.com/codex/tasks/task_e_688569dd7f208332ac95ec06b1d82f50