### PR TITLE
Add USD wallet values with cron update

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ a modal where you can update the address or its label. The **trash** icon
 removes the wallet entirely. Edits and deletions are sent to
 `get_wallets.php`, and the wallet list refreshes immediately to show the latest
 data. The wallet table on the user dashboard now also displays the current
-balance for each address.
+balance for each address. A separate cron task `cron_wallet_usd.php` updates the
+`usd_value` column of every wallet by fetching live prices from Binance. This
+value is shown in the wallet table so users can see the approximate amount in
+USD for each of their crypto holdings.
 
 The trading history table was updated as well. Amounts are shown with the
 traded coin symbol instead of dollars, e.g. `100 XRP`.
@@ -114,6 +117,12 @@ the `trades` table. Run it periodically just like the cron script:
 
 ```cron
 * * * * * php /path/to/order_processor.php
+```
+
+To keep wallet values in sync with the market, schedule `cron_wallet_usd.php` as well:
+
+```cron
+* * * * * php /path/to/cron_wallet_usd.php
 ```
 To place a pending limit order use `limit_order.php`. POST a JSON body containing `user_id`, `pair`, `quantity`, `side` and `target_price`. The script verifies the account balance and stores the order with status `open`. Once the market price reaches the target, `order_processor.php` will execute the trade and update wallets.
 

--- a/createtable.sql
+++ b/createtable.sql
@@ -47,6 +47,7 @@ CREATE TABLE wallets (
     currency VARCHAR(10) NOT NULL,
     amount DECIMAL(20,10) NOT NULL DEFAULT 0,
     purchase_price DECIMAL(20,10) DEFAULT 0,
+    usd_value DECIMAL(20,10) DEFAULT 0,
     network TEXT,
     address TEXT,
     label TEXT,

--- a/cron_wallet_usd.php
+++ b/cron_wallet_usd.php
@@ -1,0 +1,23 @@
+<?php
+// Update wallet USD values using live prices
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+function getPrice(string $currency): float {
+    $symbol = strtoupper($currency);
+    if ($symbol === 'USDT' || $symbol === 'USDC') {
+        return 1.0; // stablecoins pegged to USD
+    }
+    $url = 'https://api.binance.com/api/v3/ticker/price?symbol=' . $symbol . 'USDT';
+    $data = @json_decode(file_get_contents($url), true);
+    return isset($data['price']) ? (float)$data['price'] : 0.0;
+}
+
+$currencies = $pdo->query('SELECT DISTINCT currency FROM wallets')->fetchAll(PDO::FETCH_COLUMN);
+foreach ($currencies as $cur) {
+    $price = getPrice($cur);
+    if ($price <= 0) continue;
+    $stmt = $pdo->prepare('UPDATE wallets SET usd_value = amount * ? WHERE currency = ?');
+    $stmt->execute([$price, $cur]);
+}
+

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1105,6 +1105,7 @@
 <th>Réseau</th>
 <th>Adresse du portefeuille</th>
 <th>Solde</th>
+<th>Valeur (USD)</th>
 <th>Actions</th>
 </tr>
 </thead>

--- a/insertdata.sql
+++ b/insertdata.sql
@@ -18,8 +18,8 @@ INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES
     (1, 'USDT', 'USDT123...');
 
 
-INSERT INTO wallets (id, user_id, currency, amount, purchase_price, network, address, label) VALUES (
-    1751038645430, 1, 'btc', 0, 0,
+INSERT INTO wallets (id, user_id, currency, amount, purchase_price, usd_value, network, address, label) VALUES (
+    1751038645430, 1, 'btc', 0, 0, 0,
     'Bitcoin',
     'BTC12345678', ''
 );

--- a/script.js
+++ b/script.js
@@ -264,6 +264,7 @@ function renderWalletTable(wallets = dashboardData.personalData.wallets || []) {
                 <td>${escapeHtml(w.network)}</td>
                 <td class="wallet-address">${escapeHtml(w.address || '---')}</td>
                 <td>${formatCrypto(w.amount)} ${escapeHtml((w.currency || '').toUpperCase())}</td>
+                <td>${formatDollar(w.usd_value || 0)}</td>
                 <td>
                     <button class="btn btn-sm btn-outline-primary me-1 wallet-edit" data-id="${escapeHtml(w.id)}"><i class="fas fa-edit"></i></button>
                     <button class="btn btn-sm btn-outline-danger wallet-delete" data-id="${escapeHtml(w.id)}"><i class="fas fa-trash"></i></button>

--- a/setter.php
+++ b/setter.php
@@ -45,8 +45,8 @@ try {
     $pdo->prepare('DELETE FROM wallets WHERE user_id = ?')->execute([$userId]);
     if ($wallets) {
         $stmt = $pdo->prepare(
-            'INSERT INTO wallets (id,user_id,currency,network,address,label,amount,purchase_price) '
-            . 'VALUES (?,?,?,?,?,?,?,?)'
+            'INSERT INTO wallets (id,user_id,currency,network,address,label,amount,purchase_price,usd_value) '
+            . 'VALUES (?,?,?,?,?,?,?,?,?)'
         );
         foreach ($wallets as $w) {
             $stmt->execute([
@@ -57,7 +57,8 @@ try {
                 $w['address'] ?? '',
                 $w['label'] ?? '',
                 isset($w['amount']) ? $w['amount'] : 0,
-                isset($w['purchase_price']) ? $w['purchase_price'] : 0
+                isset($w['purchase_price']) ? $w['purchase_price'] : 0,
+                isset($w['usd_value']) ? $w['usd_value'] : 0
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- store a `usd_value` for each wallet
- cron script `cron_wallet_usd.php` refreshes wallet values from Binance
- show the USD value column on the user dashboard
- handle new column in JS and server insert logic
- document the cron job in README

## Testing
- `php -l cron_wallet_usd.php`
- `php -l setter.php`
- `ls *.php | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68868686ecd08332972fd02e527cc245