### PR TITLE
Fix wallet order sync

### DIFF
--- a/advanced_order.php
+++ b/advanced_order.php
@@ -77,7 +77,11 @@ try {
         $stmt = $pdo->prepare('SELECT amount FROM wallets WHERE user_id=? AND currency=?');
         $stmt->execute([$userId,$base]);
         $bal = $stmt->fetchColumn();
-        if($bal===false || $bal < $quantity) {
+        $pending = $pdo->prepare("SELECT SUM(quantity) FROM orders WHERE user_id=? AND side='sell' AND status='open' AND pair LIKE ?");
+        $pending->execute([$userId, $base.'/%']);
+        $reserved = (float)$pending->fetchColumn();
+        $available = $bal !== false ? $bal - $reserved : -1;
+        if($available < $quantity) {
             http_response_code(400);
             echo json_encode(['status'=>'error','message'=>'Solde insuffisant']);
             exit;

--- a/limit_order.php
+++ b/limit_order.php
@@ -44,7 +44,11 @@ try {
         $stmt = $pdo->prepare('SELECT amount FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
         $stmt->execute([$userId, $base]);
         $bal = $stmt->fetchColumn();
-        if ($bal === false || $bal < $quantity) {
+        $pending = $pdo->prepare("SELECT SUM(quantity) FROM orders WHERE user_id=? AND side='sell' AND status='open' AND pair LIKE ?");
+        $pending->execute([$userId, $base.'/%']);
+        $reserved = (float)$pending->fetchColumn();
+        $available = $bal !== false ? $bal - $reserved : -1;
+        if ($available < $quantity) {
             http_response_code(400);
             echo json_encode(['status' => 'error', 'message' => 'Solde insuffisant']);
             exit;

--- a/market_order.php
+++ b/market_order.php
@@ -61,13 +61,9 @@ try {
             return false;
         }
         $newAmt = $row['amount'] - $amount;
-        if ($newAmt > 0) {
-            $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?')
-                ->execute([$newAmt, $userId, $currency]);
-        } else {
-            $pdo->prepare('DELETE FROM wallets WHERE user_id=? AND currency=?')
-                ->execute([$userId, $currency]);
-        }
+        if ($newAmt < 0) $newAmt = 0;
+        $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?')
+            ->execute([$newAmt, $userId, $currency]);
         return (float)$row['purchase_price'];
     }
 

--- a/order_processor.php
+++ b/order_processor.php
@@ -69,12 +69,9 @@ function deductFromWallet(PDO $pdo, int $userId, string $currency, float $amount
         return false;
     }
     $newAmount = $row['amount'] - $amount;
-    if ($newAmount > 0) {
-        $upd = $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?');
-        $upd->execute([$newAmount, $userId, $currency]);
-    } else {
-        $pdo->prepare('DELETE FROM wallets WHERE user_id=? AND currency=?')->execute([$userId, $currency]);
-    }
+    if ($newAmount < 0) $newAmount = 0;
+    $upd = $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?');
+    $upd->execute([$newAmount, $userId, $currency]);
     return (float)$row['purchase_price'];
 }
 


### PR DESCRIPTION
## Summary
- prevent over selling by checking open sell orders in limit and advanced orders
- keep empty wallets instead of deleting

## Testing
- `php -l limit_order.php`
- `php -l advanced_order.php`
- `php -l market_order.php`
- `php -l order_processor.php`


------
https://chatgpt.com/codex/tasks/task_e_68868ecca4708332bede0f734f4caaf1