### PR TITLE
Update wallet deduction for sell orders

### DIFF
--- a/script.js
+++ b/script.js
@@ -1671,7 +1671,7 @@ function initializeUI() {
                 dashboardData.personalData.wallets = wallets;
             }
             renderWalletTable(wallets);
-        } else if (!isBuy && orderType === 'market') {
+        } else if (!isBuy) {
             const baseCurr = pair.replace(/USD$/, '').toLowerCase();
             let wallets = dashboardData.personalData.wallets || [];
             let w = wallets.find(x => x.currency === baseCurr);


### PR DESCRIPTION
## Summary
- remove order type check when deducting sold coins from user wallets in `script.js`
- this deducts wallet balances immediately when placing any sell order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688691057548833297289e555027f352