### PR TITLE
Fix trade value display in transactions table

### DIFF
--- a/script.js
+++ b/script.js
@@ -1417,7 +1417,9 @@ function initializeUI() {
         order.admin_id = dashboardData.personalData?.linked_to_id || null;
         dashboardData.tradingHistory.unshift(order);
         dashboardData.tradingHistory = dashboardData.tradingHistory.slice(0, 5);
-        addTransactionRecord('Trading', order.montant, order.statut, order.statutClass, order.operationNumber);
+        // Record the dollar value of the trade rather than just the quantity
+        const tradeValue = order.montant * order.prix;
+        addTransactionRecord('Trading', tradeValue, order.statut, order.statutClass, order.operationNumber);
         saveDashboardData();
         renderTradingHistory();
         loadTransactions();


### PR DESCRIPTION
## Summary
- show actual trade value in transactions table by multiplying quantity with price

## Testing
- `php -l admin_getter.php`
- `node -e "require('fs').readFileSync('script.js');"`

------
https://chatgpt.com/codex/tasks/task_e_688692fe41c08332a42fc4f989f73447