### PR TITLE
Update trading order handling

### DIFF
--- a/advanced_order.php
+++ b/advanced_order.php
@@ -96,7 +96,28 @@ try {
     $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,target_price,stop_price,status) VALUES (?,?,?,?,?,?,?,?)');
     $stmt->execute([$userId,$pair,$type,$side,$quantity,$target,$stop,'open']);
 
-    echo json_encode(['status'=>'ok','order_id'=>$pdo->lastInsertId()]);
+    $orderId = $pdo->lastInsertId();
+    $opNum = 'T' . $orderId;
+    $date = date('Y/m/d');
+    $adm = $pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id=?');
+    $adm->execute([$userId]);
+    $adminId = $adm->fetchColumn() ?: null;
+    $approx = ($target ?? $stop ?? getLivePrice($pair)) * $quantity;
+    $pdo->prepare(
+        'INSERT INTO transactions (user_id,admin_id,operationNumber,type,amount,date,status,statusClass) '
+        . 'VALUES (?,?,?,?,?,?,?,?)'
+    )->execute([
+        $userId,
+        $adminId,
+        $opNum,
+        'Trading',
+        $approx,
+        $date,
+        'En cours',
+        'bg-warning'
+    ]);
+
+    echo json_encode(['status'=>'ok','order_id'=>$orderId]);
 } catch(Throwable $e) {
     error_log(__FILE__.' - '.$e->getMessage());
     http_response_code(500);

--- a/limit_order.php
+++ b/limit_order.php
@@ -53,10 +53,30 @@ try {
     $stmt = $pdo->prepare("INSERT INTO orders (user_id,pair,type,side,quantity,target_price,status) VALUES (?,?,?,?,?,?,?)");
     $stmt->execute([$userId, $pair, 'limit', $side, $quantity, $target, 'open']);
 
+    $orderId = $pdo->lastInsertId();
+    $opNum = 'T' . $orderId;
+    $date = date('Y/m/d');
+    $adm = $pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id=?');
+    $adm->execute([$userId]);
+    $adminId = $adm->fetchColumn() ?: null;
+    $pdo->prepare(
+        'INSERT INTO transactions (user_id,admin_id,operationNumber,type,amount,date,status,statusClass) '
+        . 'VALUES (?,?,?,?,?,?,?,?)'
+    )->execute([
+        $userId,
+        $adminId,
+        $opNum,
+        'Trading',
+        $target * $quantity,
+        $date,
+        'En cours',
+        'bg-warning'
+    ]);
+
     echo json_encode([
         'status' => 'ok',
         'message' => "Ordre limite de {$quantity} {$base} au prix de {$target} {$quote} créé",
-        'order_id' => $pdo->lastInsertId()
+        'order_id' => $orderId
     ]);
 } catch (Throwable $e) {
     if (isset($pdo) && $pdo->inTransaction()) $pdo->rollBack();

--- a/market_order.php
+++ b/market_order.php
@@ -120,6 +120,26 @@ try {
     );
     $stmt->execute([$userId, $pair, $side, $quantity, $price, $total, $profit]);
 
+    // create matching transaction record
+    $opNum = 'T' . $pdo->lastInsertId();
+    $date = date('Y/m/d');
+    $adm = $pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id=?');
+    $adm->execute([$userId]);
+    $adminId = $adm->fetchColumn() ?: null;
+    $pdo->prepare(
+        'INSERT INTO transactions (user_id,admin_id,operationNumber,type,amount,date,status,statusClass) '
+        . 'VALUES (?,?,?,?,?,?,?,?)'
+    )->execute([
+        $userId,
+        $adminId,
+        $opNum,
+        'Trading',
+        $total,
+        $date,
+        'complet',
+        'bg-success'
+    ]);
+
     $pdo->commit();
     $actionMsg = $side === 'buy'
         ? "Achat de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}"

--- a/order_processor.php
+++ b/order_processor.php
@@ -127,6 +127,11 @@ function executeOrder(PDO $pdo, array $order, float $price): void {
         $profit = ($price - $purchase) * $qty;
     }
     recordTrade($pdo, $order, $price, $profit);
+
+    // mark related transaction as complete
+    $opNum = 'T' . $order['id'];
+    $pdo->prepare("UPDATE transactions SET status='complet', statusClass='bg-success' WHERE operationNumber=?")
+        ->execute([$opNum]);
 }
 /**
  * Determine if an order should execute at the given price.


### PR DESCRIPTION
## Summary
- create transaction entries when market orders execute
- store new transaction rows when placing limit and advanced orders
- finalize related transactions when orders are executed

## Testing
- `php -l market_order.php`
- `php -l limit_order.php`
- `php -l advanced_order.php`
- `php -l order_processor.php`

------
https://chatgpt.com/codex/tasks/task_e_688697662bbc83328d039fb643111ad4