### PR TITLE
Fix transaction amount after trades execute

### DIFF
--- a/cron_trading.php
+++ b/cron_trading.php
@@ -78,8 +78,9 @@ foreach ($orders as $o) {
         $invested = $details['invested'] ?? ($entry * $qty);
         $pdo->prepare("UPDATE tradingHistory SET profitPerte=?, profitClass=?, statut='complet', statutClass='bg-success', details=? WHERE id=?")
             ->execute([$profit, $profitClass, json_encode($details), $o['id']]);
-        $pdo->prepare("UPDATE transactions SET status='complet', statusClass='bg-success' WHERE operationNumber=?")
-            ->execute([$o['operationNumber']]);
+        $pdo->prepare(
+            "UPDATE transactions SET amount=?, status='complet', statusClass='bg-success' WHERE operationNumber=?"
+        )->execute([$invested, $o['operationNumber']]);
         $pdo->prepare("UPDATE personal_data SET balance = balance + ? WHERE user_id=?")
             ->execute([$invested + $profit, $o['user_id']]);
 

--- a/order_processor.php
+++ b/order_processor.php
@@ -128,10 +128,11 @@ function executeOrder(PDO $pdo, array $order, float $price): void {
     }
     recordTrade($pdo, $order, $price, $profit);
 
-    // mark related transaction as complete
+    // mark related transaction as complete and update the executed amount
     $opNum = 'T' . $order['id'];
-    $pdo->prepare("UPDATE transactions SET status='complet', statusClass='bg-success' WHERE operationNumber=?")
-        ->execute([$opNum]);
+    $pdo->prepare(
+        "UPDATE transactions SET amount=?, status='complet', statusClass='bg-success' WHERE operationNumber=?"
+    )->execute([$total, $opNum]);
 }
 /**
  * Determine if an order should execute at the given price.


### PR DESCRIPTION
## Summary
- ensure executed trades update the associated transaction amount
- reflect executed value when closing trades in `cron_trading.php`

## Testing
- `php -l order_processor.php`
- `php -l cron_trading.php`


------
https://chatgpt.com/codex/tasks/task_e_68869a1f4ef483328ce616b8fee5c855