### PR TITLE
Remove PHP logic covered by DB triggers

### DIFF
--- a/admin_setter.php
+++ b/admin_setter.php
@@ -102,16 +102,6 @@ try {
         $stmt = $pdo->prepare($sql);
         $stmt->execute(array_values($user));
 
-        $pdo->prepare('INSERT INTO verification_status (user_id,enregistrementducompte,confirmationdeladresseemail,telechargerlesdocumentsdidentite,verificationdeladresse,revisionfinale) VALUES (?,?,?,?,?,?)')
-            ->execute([
-                $user['user_id'],
-                1,
-                1,
-                0,
-                0,
-                2
-            ]);
-
         if (!empty($data['bankWithdrawInfo']) && is_array($data['bankWithdrawInfo'])) {
             $bw = $data['bankWithdrawInfo'];
             $bwCols = ['user_id','widhrawBankName','widhrawAccountName','widhrawAccountNumber','widhrawIban','widhrawSwiftCode'];
@@ -281,23 +271,7 @@ try {
                 }
                 $pdo->prepare("DELETE FROM transactions WHERE operationNumber = ?")->execute([$op]);
                 if ($oldStatus === 'complet') {
-                    if ($prefix === 'D') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)-?, '
-                            . 'totalDepots = COALESCE(totalDepots,0)-?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)-1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
-                    } elseif ($prefix === 'R') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)+?, '
-                            . 'totalRetraits = COALESCE(totalRetraits,0)-?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)-1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
-                    }
+                    // balance adjustments now handled by database triggers
                 }
             } else {
                 $status = $data['status'] ?? null;
@@ -313,13 +287,7 @@ try {
                     ->execute([$status, $class, $op]);
                 if ($prefix === 'D') {
                     if ($oldStatus !== 'complet' && $status === 'complet') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)+?, '
-                            . 'totalDepots = COALESCE(totalDepots,0)+?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)+1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
+                        // deposit completion adjustments handled by triggers
 
                         $timeAgo = formatTimeAgoFromDate($row['date']);
                         $msgAmount = number_format($amount, 0, '.', ' ') . ' $';
@@ -333,23 +301,11 @@ try {
                                 'alert-success'
                             ]);
                     } elseif ($oldStatus === 'complet' && $status !== 'complet') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)-?, '
-                            . 'totalDepots = COALESCE(totalDepots,0)-?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)-1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
+                        // revert handled by trigger trg_deposits_after_update
                     }
                 } elseif ($prefix === 'R') {
                     if ($oldStatus !== 'complet' && $status === 'complet') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)-?, '
-                            . 'totalRetraits = COALESCE(totalRetraits,0)+?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)+1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
+                        // withdrawal completion handled by trigger trg_retraits_after_update
 
                         $timeAgo = formatTimeAgoFromDate($row['date']);
                         $msgAmount = number_format($amount, 0, '.', ' ') . ' $';
@@ -363,13 +319,7 @@ try {
                                 'alert-success'
                             ]);
                     } elseif ($oldStatus === 'complet' && $status !== 'complet') {
-                        $pdo->prepare(
-                            'UPDATE personal_data SET '
-                            . 'balance = COALESCE(balance,0)+?, '
-                            . 'totalRetraits = COALESCE(totalRetraits,0)-?, '
-                            . 'nbTransactions = COALESCE(nbTransactions,0)-1 '
-                            . 'WHERE user_id = ?'
-                        )->execute([$amount, $amount, $userId]);
+                        // revert handled by trigger trg_retraits_after_update
                     }
                 }
         }

--- a/market_order.php
+++ b/market_order.php
@@ -119,27 +119,6 @@ try {
         . 'VALUES (?,?,?,?,?,?,0,?)'
     );
     $stmt->execute([$userId, $pair, $side, $quantity, $price, $total, $profit]);
-
-    // create matching transaction record
-    $opNum = 'T' . $pdo->lastInsertId();
-    $date = date('Y/m/d');
-    $adm = $pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id=?');
-    $adm->execute([$userId]);
-    $adminId = $adm->fetchColumn() ?: null;
-    $pdo->prepare(
-        'INSERT INTO transactions (user_id,admin_id,operationNumber,type,amount,date,status,statusClass) '
-        . 'VALUES (?,?,?,?,?,?,?,?)'
-    )->execute([
-        $userId,
-        $adminId,
-        $opNum,
-        'Trading',
-        $total,
-        $date,
-        'complet',
-        'bg-success'
-    ]);
-
     $pdo->commit();
     $actionMsg = $side === 'buy'
         ? "Achat de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}"


### PR DESCRIPTION
## Summary
- rely on `triggers.sql` to populate `verification_status` on user creation
- rely on triggers for balance updates when deposits or withdrawals change
- let `trades` trigger insert transactions automatically

## Testing
- `php -l admin_setter.php`
- `php -l market_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6887bdabed04833291ad2472d0f4346f