### PR TITLE
Implement full order management

### DIFF
--- a/createtable.sql
+++ b/createtable.sql
@@ -186,6 +186,24 @@ CREATE TABLE verification_status (
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
         ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB;
+CREATE TABLE orders (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    pair VARCHAR(20),
+    type ENUM('market','limit','stop','stop_limit','trailing_stop','oco'),
+    side ENUM('buy','sell'),
+    quantity DECIMAL(20,10),
+    target_price DECIMAL(20,10),
+    stop_price DECIMAL(20,10),
+    trailing_percentage DECIMAL(10,4),
+    trail_price DECIMAL(20,10),
+    status ENUM('open','triggered','filled','cancelled') DEFAULT 'open',
+    price_at_execution DECIMAL(20,10),
+    executed_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 
 
 CREATE TABLE trades (
@@ -194,10 +212,12 @@ CREATE TABLE trades (
     pair VARCHAR(20),
     side ENUM('buy','sell'),
     quantity DECIMAL(20,10),
+    order_id BIGINT,
     price DECIMAL(20,10),
     total_value DECIMAL(20,10),
     fee DECIMAL(20,10) DEFAULT 0,
     profit_loss DECIMAL(20,10),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE SET NULL,
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE,
 ) ENGINE=InnoDB;

--- a/cron_process_orders.php
+++ b/cron_process_orders.php
@@ -1,0 +1,131 @@
+<?php
+// Cron job to evaluate pending orders and execute when conditions meet
+$dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+$pdo = new PDO($dsn, 'root', '', [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+function getLivePrice(string $pair): float {
+    $symbol = str_replace('/', '', strtoupper($pair));
+    $symbol = str_replace('USD', 'USDT', $symbol);
+    $url = 'https://api.binance.com/api/v3/ticker/price?symbol=' . $symbol;
+    $data = @json_decode(file_get_contents($url), true);
+    return isset($data['price']) ? (float)$data['price'] : 0.0;
+}
+
+function addToWallet(PDO $pdo,int $uid,string $cur,float $amt,float $price){
+    $cur = strtolower($cur);
+    $st=$pdo->prepare('SELECT amount,purchase_price FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
+    $st->execute([$uid,$cur]);
+    $row=$st->fetch(PDO::FETCH_ASSOC);
+    if($row){
+        $new=$row['amount']+$amt;
+        $avg=($row['amount']*$row['purchase_price']+$amt*$price)/$new;
+        $pdo->prepare('UPDATE wallets SET amount=?, purchase_price=? WHERE user_id=? AND currency=?')->execute([$new,$avg,$uid,$cur]);
+    }else{
+        $pdo->prepare('INSERT INTO wallets (user_id,currency,amount,address,label,purchase_price) VALUES (?,?,?,?,?,?)')->execute([$uid,$cur,$amt,'local address',strtoupper($cur),$price]);
+    }
+}
+function deductFromWallet(PDO $pdo,int $uid,string $cur,float $amt){
+    $cur=strtolower($cur);
+    $st=$pdo->prepare('SELECT amount,purchase_price FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
+    $st->execute([$uid,$cur]);
+    $row=$st->fetch(PDO::FETCH_ASSOC);
+    if(!$row || $row['amount']<$amt) return false;
+    $new=$row['amount']-$amt;
+    if($new>0){
+        $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?')->execute([$new,$uid,$cur]);
+    } else {
+        $pdo->prepare('DELETE FROM wallets WHERE user_id=? AND currency=?')->execute([$uid,$cur]);
+    }
+    return (float)$row['purchase_price'];
+}
+function executeTrade(PDO $pdo,array $order,float $price){
+    [$base,$quote]=explode('/',strtoupper($order['pair']));
+    $total=$price*$order['quantity'];
+    if($order['side']=='buy'){
+        $st=$pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+        $st->execute([$order['user_id']]);
+        $bal=$st->fetchColumn();
+        if($bal===false || $bal<$total) return ['ok'=>false,'msg'=>'Solde insuffisant'];
+        $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total,$order['user_id']]);
+        addToWallet($pdo,$order['user_id'],$base,$order['quantity'],$price);
+        $newBal=$bal-$total;
+        $profit=0;
+    } else {
+        $st=$pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+        $st->execute([$order['user_id']]);
+        $bal=$st->fetchColumn();
+        $purchase=deductFromWallet($pdo,$order['user_id'],$base,$order['quantity']);
+        if($purchase===false) return ['ok'=>false,'msg'=>'Solde insuffisant'];
+        $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);
+        $newBal=$bal+$total;
+        $profit=($price-$purchase)*$order['quantity'];
+    }
+    $stmt=$pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss) VALUES (?,?,?,?,?,?,?,0,?)');
+    $stmt->execute([$order['user_id'],$order['id'],$order['pair'],$order['side'],$order['quantity'],$price,$total,$profit]);
+    $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
+    if($order['related_order_id']){
+        $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=? AND status IN ('open','triggered')")->execute([$order['related_order_id']]);
+    }
+    return ['ok'=>true];
+}
+
+// fetch open and triggered orders
+$orders = $pdo->query("SELECT * FROM orders WHERE status IN ('open','triggered')")->fetchAll(PDO::FETCH_ASSOC);
+foreach ($orders as $o) {
+    $price = getLivePrice($o['pair']);
+    if ($price <= 0) continue;
+
+    switch ($o['type']) {
+        case 'limit':
+            if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
+                $pdo->beginTransaction();
+                $res = executeTrade($pdo, $o, $o['target_price']);
+                if ($res['ok']) $pdo->commit(); else $pdo->rollBack();
+            }
+            break;
+        case 'stop':
+            if (($o['side']=='buy' && $price >= $o['stop_price']) || ($o['side']=='sell' && $price <= $o['stop_price'])) {
+                $pdo->beginTransaction();
+                $res = executeTrade($pdo, $o, $price);
+                if ($res['ok']) $pdo->commit(); else $pdo->rollBack();
+            }
+            break;
+        case 'stop_limit':
+            if ($o['status']=='open') {
+                if (($o['side']=='buy' && $price >= $o['stop_price']) || ($o['side']=='sell' && $price <= $o['stop_price'])) {
+                    $pdo->prepare("UPDATE orders SET status='triggered' WHERE id=?")->execute([$o['id']]);
+                    $o['status']='triggered';
+                }
+            }
+            if ($o['status']=='triggered') {
+                if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
+                    $pdo->beginTransaction();
+                    $res = executeTrade($pdo,$o,$o['target_price']);
+                    if ($res['ok']) $pdo->commit(); else $pdo->rollBack();
+                }
+            }
+            break;
+        case 'trailing_stop':
+            if ($o['side']=='sell') {
+                if ($price > $o['trail_price']) {
+                    $pdo->prepare('UPDATE orders SET trail_price=? WHERE id=?')->execute([$price,$o['id']]);
+                    $o['trail_price']=$price;
+                } elseif ($price <= $o['trail_price']*(1-$o['trailing_percentage']/100)) {
+                    $pdo->beginTransaction();
+                    $res=executeTrade($pdo,$o,$price);
+                    if($res['ok']) $pdo->commit(); else $pdo->rollBack();
+                }
+            } else {
+                if ($price < $o['trail_price']) {
+                    $pdo->prepare('UPDATE orders SET trail_price=? WHERE id=?')->execute([$price,$o['id']]);
+                    $o['trail_price']=$price;
+                } elseif ($price >= $o['trail_price']*(1+$o['trailing_percentage']/100)) {
+                    $pdo->beginTransaction();
+                    $res=executeTrade($pdo,$o,$price);
+                    if($res['ok']) $pdo->commit(); else $pdo->rollBack();
+                }
+            }
+            break;
+    }
+}
+?>

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -229,6 +229,8 @@
 <option value="limit">Ordre à cours limité</option>
 <option value="stop">Ordre stop</option>
 <option value="stoplimit">Stop-limit</option>
+<option value="trailing_stop">Trailing stop</option>
+<option value="oco">OCO</option>
 </select>
 </div>
 <div class="mb-3" id="stopPriceDiv" style="display: none;">
@@ -243,6 +245,13 @@
 <div class="input-group">
 <input class="form-control" name="limitPrice" id="limitPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
 <span class="input-group-text">USD</span>
+</div>
+<div class="mb-3" id="stopLimitPriceDiv" style="display: none;">
+<label class="form-label" for="stopLimitPrice">Prix limite du stop</label>
+<div class="input-group">
+<input class="form-control" name="stopLimitPrice" id="stopLimitPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
+<span class="input-group-text">USD</span>
+</div>
 </div>
 </div>
 <div class="row g-2 mb-3">

--- a/place_order.php
+++ b/place_order.php
@@ -1,0 +1,127 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
+
+try {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input)) {
+        http_response_code(400);
+        echo json_encode(['status'=>'error','message'=>'Invalid JSON']);
+        exit;
+    }
+    $userId = (int)($input['user_id'] ?? 0);
+    $pair = $input['pair'] ?? '';
+    $qty = isset($input['quantity']) ? (float)$input['quantity'] : 0.0;
+    $side = strtolower($input['side'] ?? 'buy');
+    $type = strtolower($input['type'] ?? 'market');
+    $limit = isset($input['limit_price']) ? (float)$input['limit_price'] : null;
+    $stop = isset($input['stop_price']) ? (float)$input['stop_price'] : null;
+    $stopLimit = isset($input['stop_limit_price']) ? (float)$input['stop_limit_price'] : null;
+    $trailPerc = isset($input['trailing_percentage']) ? (float)$input['trailing_percentage'] : null;
+
+    if(!$userId || !$pair || $qty <= 0 || !in_array($side,['buy','sell'])){
+        http_response_code(400);
+        echo json_encode(['status'=>'error','message'=>'Missing parameters']);
+        exit;
+    }
+
+    $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
+    $pdo = new PDO($dsn,'root','',[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);
+
+    // helper functions copied from market_order.php
+    function getLivePrice(string $pair): float {
+        $symbol = str_replace('/', '', strtoupper($pair));
+        $symbol = str_replace('USD', 'USDT', $symbol);
+        $url = "https://api.binance.com/api/v3/ticker/price?symbol={$symbol}";
+        $d = @json_decode(file_get_contents($url), true);
+        return isset($d['price']) ? (float)$d['price'] : 0.0;
+    }
+    function addToWallet(PDO $pdo,int $uid,string $cur,float $amt,float $price){
+        $cur = strtolower($cur);
+        $st=$pdo->prepare('SELECT amount,purchase_price FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
+        $st->execute([$uid,$cur]);
+        $row=$st->fetch(PDO::FETCH_ASSOC);
+        if($row){
+            $new=$row['amount']+$amt;
+            $avg=($row['amount']*$row['purchase_price']+$amt*$price)/$new;
+            $pdo->prepare('UPDATE wallets SET amount=?, purchase_price=? WHERE user_id=? AND currency=?')->execute([$new,$avg,$uid,$cur]);
+        }else{
+            $pdo->prepare('INSERT INTO wallets (user_id,currency,amount,address,label,purchase_price) VALUES (?,?,?,?,?,?)')->execute([$uid,$cur,$amt,'local address',strtoupper($cur),$price]);
+        }
+    }
+    function deductFromWallet(PDO $pdo,int $uid,string $cur,float $amt){
+        $cur=strtolower($cur);
+        $st=$pdo->prepare('SELECT amount,purchase_price FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');
+        $st->execute([$uid,$cur]);
+        $row=$st->fetch(PDO::FETCH_ASSOC);
+        if(!$row || $row['amount']<$amt) return false;
+        $new=$row['amount']-$amt;
+        if($new>0){
+            $pdo->prepare('UPDATE wallets SET amount=? WHERE user_id=? AND currency=?')->execute([$new,$uid,$cur]);
+        } else {
+            $pdo->prepare('DELETE FROM wallets WHERE user_id=? AND currency=?')->execute([$uid,$cur]);
+        }
+        return (float)$row['purchase_price'];
+    }
+    function executeTrade(PDO $pdo,array $order,float $price){
+        [$base,$quote]=explode('/',strtoupper($order['pair']));
+        $total=$price*$order['quantity'];
+        if($order['side']=='buy'){
+            $st=$pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+            $st->execute([$order['user_id']]);
+            $bal=$st->fetchColumn();
+            if($bal===false || $bal<$total) return ['ok'=>false,'msg'=>'Solde insuffisant'];
+            $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total,$order['user_id']]);
+            addToWallet($pdo,$order['user_id'],$base,$order['quantity'],$price);
+            $newBal=$bal-$total;
+            $profit=0;
+        } else {
+            $st=$pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+            $st->execute([$order['user_id']]);
+            $bal=$st->fetchColumn();
+            $purchase=deductFromWallet($pdo,$order['user_id'],$base,$order['quantity']);
+            if($purchase===false) return ['ok'=>false,'msg'=>'Solde insuffisant'];
+            $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);
+            $newBal=$bal+$total;
+            $profit=($price-$purchase)*$order['quantity'];
+        }
+        $stmt=$pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss) VALUES (?,?,?,?,?,?,?,0,?)');
+        $stmt->execute([$order['user_id'],$order['id'],$order['pair'],$order['side'],$order['quantity'],$price,$total,$profit]);
+        $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
+        return ['ok'=>true,'balance'=>$newBal,'price'=>$price];
+    }
+
+    $livePrice = getLivePrice($pair);
+    if($livePrice<=0) $livePrice = 0.0;
+
+    if($type==='market'){
+        $pdo->beginTransaction();
+        $order=['id'=>0,'user_id'=>$userId,'pair'=>$pair,'side'=>$side,'quantity'=>$qty];
+        $result = executeTrade($pdo,$order,$livePrice);
+        if(!$result['ok']){ $pdo->rollBack(); http_response_code(400); echo json_encode(['status'=>'error','message'=>$result['msg']]); return; }
+        $pdo->commit();
+        echo json_encode(['status'=>'ok','price'=>$result['price'],'new_balance'=>$result['balance']]);
+        return;
+    }
+
+    // For pending orders just record
+    $stmt=$pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,target_price,stop_price,trailing_percentage,trail_price,related_order_id) VALUES (?,?,?,?,?,?,?,?,?,NULL)');
+    $trailPrice = $livePrice>0 ? $livePrice : null;
+    $stmt->execute([$userId,$pair,$type,$side,$qty,$limit,$stop,$trailPerc,$trailPrice]);
+    $id=$pdo->lastInsertId();
+
+    if($type==='oco'){
+        // create second order for stop limit part using provided stop_limit_price
+        $stopLimitOrder=$pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,target_price,stop_price,related_order_id) VALUES (?,?,?,?,?,?,?,?)');
+        $stopLimitOrder->execute([$userId,$pair,'stop_limit',$side,$qty,$stopLimit,$stop,$id]);
+        $secondId=$pdo->lastInsertId();
+        $pdo->prepare('UPDATE orders SET related_order_id=? WHERE id=?')->execute([$secondId,$id]);
+    }
+
+    echo json_encode(['status'=>'ok','order_id'=>$id]);
+} catch(Throwable $e){
+    if(isset($pdo)&&$pdo->inTransaction()) $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['status'=>'error','message'=>$e->getMessage()]);
+}
+?>

--- a/script.js
+++ b/script.js
@@ -1458,7 +1458,11 @@ function initializeUI() {
     });
 
     $('#orderType').on('change', function () {
-        // only market orders supported
+        const t = $(this).val();
+        $('#limitPriceDiv').toggle(t === 'limit' || t === 'stoplimit' || t === 'oco');
+        $('#stopPriceDiv').toggle(t === 'stop' || t === 'stoplimit' || t === 'oco');
+        $('#stopLimitPriceDiv').toggle(t === 'oco');
+        $('#trailingPercentageDiv').toggle(t === 'trailing_stop');
     });
 
     $('#buyBtn, #sellBtn').on('click', async function () {
@@ -1469,25 +1473,39 @@ function initializeUI() {
             alert('Veuillez entrer un montant valide');
             return;
         }
-        const orderType = 'market';
+        const orderType = $('#orderType').val();
         let price = currentPrice;
         let cost = amount * price;
-        if (cost > parseDollar(dashboardData.personalData.balance)) {
+        const apiPair = pair.replace('USD', '/USD');
+        let resp;
+        const payload = { user_id: userId, pair: apiPair, quantity: amount, side: isBuy ? 'buy' : 'sell', type: orderType };
+        if (orderType === 'limit' || orderType === 'stoplimit' || orderType === 'oco') {
+            payload.limit_price = parseFloat($('#limitPrice').val());
+            if (orderType === 'limit') cost = amount * payload.limit_price;
+        }
+        if (orderType === 'stop' || orderType === 'stoplimit' || orderType === 'oco') {
+            payload.stop_price = parseFloat($('#stopPrice').val());
+        }
+        if (orderType === 'stoplimit' || orderType === 'oco') {
+            payload.stop_limit_price = parseFloat($('#stopLimitPrice').val());
+        }
+        if (orderType === 'trailing_stop') {
+            payload.trailing_percentage = parseFloat($('#trailingPercentage').val());
+        }
+
+        if (orderType === 'market' && cost > parseDollar(dashboardData.personalData.balance)) {
             alert('Solde insuffisant');
             return;
         }
-        const apiPair = pair.replace('USD', '/USD');
-        let resp;
+
         try {
-            const payload = { user_id: userId, pair: apiPair, quantity: amount, side: isBuy ? 'buy' : 'sell' };
-            resp = await apiFetch('market_order.php', {
+            const url = orderType === 'market' ? 'market_order.php' : 'place_order.php';
+            resp = await apiFetch(url, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
             });
-            if (resp.price) {
-                price = parseFloat(resp.price);
-            }
+            if (resp.price) price = parseFloat(resp.price);
             if (resp.new_balance !== undefined) {
                 dashboardData.personalData.balance = parseFloat(resp.new_balance);
             }
@@ -1497,46 +1515,48 @@ function initializeUI() {
             return;
         }
 
-        let newBalance = parseDollar(dashboardData.personalData.balance);
-        if (resp && resp.new_balance !== undefined) {
-            newBalance = parseFloat(resp.new_balance);
-        } else if (isBuy) {
-            newBalance -= amount * price;
-        } else {
-            newBalance += amount * price;
-        }
-        dashboardData.personalData.balance = newBalance;
-
-        if (isBuy) {
-            const baseCurr = pair.replace(/USD$/, '').toLowerCase();
-            let wallets = dashboardData.personalData.wallets || [];
-            let w = wallets.find(x => x.currency === baseCurr);
-            if (w) {
-                w.amount = parseFloat(w.amount || 0) + amount;
+        if (orderType === 'market') {
+            let newBalance = parseDollar(dashboardData.personalData.balance);
+            if (resp && resp.new_balance !== undefined) {
+                newBalance = parseFloat(resp.new_balance);
+            } else if (isBuy) {
+                newBalance -= amount * price;
             } else {
-                w = {
-                    id: Date.now(),
-                    currency: baseCurr,
-                    amount: amount,
-                    network: '',
-                    address: 'local address',
-                    label: baseCurr.toUpperCase()
-                };
-                wallets.push(w);
-                dashboardData.personalData.wallets = wallets;
+                newBalance += amount * price;
             }
-            renderWalletTable(wallets);
-        } else {
-            const baseCurr = pair.replace(/USD$/, '').toLowerCase();
-            let wallets = dashboardData.personalData.wallets || [];
-            let w = wallets.find(x => x.currency === baseCurr);
-            if (w) {
-                w.amount = Math.max(0, parseFloat(w.amount || 0) - amount);
+            dashboardData.personalData.balance = newBalance;
+
+            if (isBuy) {
+                const baseCurr = pair.replace(/USD$/, '').toLowerCase();
+                let wallets = dashboardData.personalData.wallets || [];
+                let w = wallets.find(x => x.currency === baseCurr);
+                if (w) {
+                    w.amount = parseFloat(w.amount || 0) + amount;
+                } else {
+                    w = {
+                        id: Date.now(),
+                        currency: baseCurr,
+                        amount: amount,
+                        network: '',
+                        address: 'local address',
+                        label: baseCurr.toUpperCase()
+                    };
+                    wallets.push(w);
+                    dashboardData.personalData.wallets = wallets;
+                }
+                renderWalletTable(wallets);
+            } else {
+                const baseCurr = pair.replace(/USD$/, '').toLowerCase();
+                let wallets = dashboardData.personalData.wallets || [];
+                let w = wallets.find(x => x.currency === baseCurr);
+                if (w) {
+                    w.amount = Math.max(0, parseFloat(w.amount || 0) - amount);
+                }
+                renderWalletTable(wallets);
             }
-            renderWalletTable(wallets);
+            saveDashboardData();
+            updateBalances();
         }
-        saveDashboardData();
-        updateBalances();
 
         const order = {
             temps: new Date().toLocaleString(),


### PR DESCRIPTION
## Summary
- add `orders` table and link trades with `order_id`
- implement advanced order placement in `place_order.php`
- cron job `cron_process_orders.php` evaluates open orders
- extend dashboard UI for order types
- update front-end JS to send new order parameters

## Testing
- `php -l place_order.php`
- `php -l cron_process_orders.php`
- `php -l market_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6887c58786d08332bbe212a377832de5