### PR TITLE
Enable stop loss UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,21 @@
+$(function() {
+    function updateStopLossFields() {
+        const type = $('#stopLossType').val();
+        $('#stopLossPriceDiv').toggle(type === 'price');
+        $('#stopLossPercentageDiv').toggle(type === 'percentage');
+        $('#stopLossTimeDiv').toggle(type === 'time');
+        $('#trailingPercentageDiv').toggle(type === 'trailing');
+    }
+
+    $('#enableStopLoss').on('change', function() {
+        $('#stopLossSettings').toggle(this.checked);
+    });
+
+    $('#stopLossType').on('change', updateStopLossFields);
+
+    $('#enableOCO').on('change', function() {
+        $('#takeProfitDiv').toggle(this.checked);
+    });
+
+    updateStopLossFields();
+});


### PR DESCRIPTION
## Summary
- add a new front‑end script to control stop loss settings
- load the script in the user dashboard

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887cd4cc4e0833299b0cd0db1d38de6