### PR TITLE
Implement WebSocket infrastructure for live dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/websocket/node_modules
+/websocket/package-lock.json

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1533,6 +1533,18 @@
 <!-- Bootstrap Bundle -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
+<!-- Socket.IO for real-time updates -->
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+<script src="js/socketClient.js"></script>
+<script>
+  $(function(){
+    const uid = localStorage.getItem('user_id');
+    if(uid){
+      connectSocket(uid);
+    }
+  });
+</script>
+
 
 
 

--- a/js/socketClient.js
+++ b/js/socketClient.js
@@ -1,0 +1,29 @@
+let socket;
+function connectSocket(userId) {
+  socket = io('http://localhost:3001');
+  socket.on('connect', () => {
+    socket.emit('join', userId);
+  });
+  socket.on('balance_updated', data => {
+    if (window.updateBalance) {
+      window.updateBalance(data.newBalance);
+    } else if (window.dashboardData && window.dashboardData.personalData) {
+      window.dashboardData.personalData.balance = parseFloat(data.newBalance);
+      if (typeof window.refreshUI === 'function') window.refreshUI();
+    }
+  });
+  socket.on('wallet_updated', () => {
+    if (typeof fetchDashboardData === 'function') {
+      fetchDashboardData();
+    }
+  });
+  socket.on('new_trade', trade => {
+    if (window.addTrade) window.addTrade(trade);
+  });
+  socket.on('order_filled', order => {
+    if (window.handleOrderFilled) window.handleOrderFilled(order);
+  });
+  socket.on('new_order', order => {
+    if (window.handleNewOrder) window.handleNewOrder(order);
+  });
+}

--- a/php/market_order.php
+++ b/php/market_order.php
@@ -78,6 +78,18 @@ try {
     );
     $stmt->execute([$userId, $pair, $side, $quantity, $price, $total, $profit]);
     $pdo->commit();
+
+    require_once __DIR__.'/../utils/socket.php';
+    emitEvent('balance_updated', ['newBalance' => $newBalance], $userId);
+    emitEvent('wallet_updated', [], $userId);
+    emitEvent('new_trade', [
+        'pair' => $pair,
+        'side' => $side,
+        'quantity' => $quantity,
+        'price' => $price,
+        'profit_loss' => $profit
+    ], $userId);
+
     $actionMsg = $side === 'buy'
         ? "Achat de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}"
         : "Vente de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}";

--- a/php/notifyFrontend.php
+++ b/php/notifyFrontend.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/../utils/socket.php';
+header('Content-Type: application/json');
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input) || empty($input['event'])) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Missing event']);
+    exit;
+}
+$userId = $input['user_id'] ?? null;
+$data = $input['data'] ?? [];
+if (emitEvent($input['event'], $data, $userId)) {
+    echo json_encode(['status' => 'ok']);
+} else {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Failed to emit']);
+}
+?>

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -39,6 +39,15 @@ try {
         $result = executeTrade($pdo,$order,$livePrice);
         if(!$result['ok']){ $pdo->rollBack(); http_response_code(400); echo json_encode(['status'=>'error','message'=>$result['msg']]); return; }
         $pdo->commit();
+        require_once __DIR__.'/../utils/socket.php';
+        emitEvent('balance_updated', ['newBalance' => $result['balance']], $userId);
+        emitEvent('wallet_updated', [], $userId);
+        emitEvent('order_filled', [
+            'pair' => $pair,
+            'side' => $side,
+            'quantity' => $qty,
+            'price' => $result['price']
+        ], $userId);
         echo json_encode(['status'=>'ok','price'=>$result['price'],'new_balance'=>$result['balance']]);
         return;
     }
@@ -48,6 +57,17 @@ try {
     $trailPrice = $livePrice>0 ? $livePrice : null;
     $stmt->execute([$userId,$pair,$type,$side,$qty,$limit,$stop,$trailPerc,$trailPrice]);
     $id=$pdo->lastInsertId();
+
+    require_once __DIR__.'/../utils/socket.php';
+    emitEvent('new_order', [
+        'order_id' => $id,
+        'pair' => $pair,
+        'type' => $type,
+        'side' => $side,
+        'quantity' => $qty,
+        'target_price' => $limit,
+        'stop_price' => $stop
+    ], $userId);
 
     if($type==='oco'){
         // create second order for stop limit part using provided stop_limit_price

--- a/php/setter.php
+++ b/php/setter.php
@@ -139,6 +139,15 @@ try {
     }
 
     $pdo->commit();
+
+    require_once __DIR__.'/../utils/socket.php';
+    $stmt = $pdo->prepare('SELECT balance FROM personal_data WHERE user_id = ?');
+    $stmt->execute([$userId]);
+    $bal = $stmt->fetchColumn();
+    emitEvent('balance_updated', ['newBalance' => $bal], $userId);
+    emitEvent('wallet_updated', [], $userId);
+    emitEvent('data_saved', [], $userId);
+
     echo json_encode(['status' => 'ok']);
 } catch (Throwable $e) {
     $pdo->rollBack();

--- a/utils/socket.php
+++ b/utils/socket.php
@@ -1,0 +1,17 @@
+<?php
+function emitEvent(string $event, array $data = [], $userId = null): bool {
+    $payload = json_encode(['event' => $event, 'data' => $data, 'userId' => $userId]);
+    $ch = curl_init('http://localhost:3001/emit');
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+        CURLOPT_POSTFIELDS => $payload,
+        CURLOPT_TIMEOUT => 2
+    ]);
+    $res = curl_exec($ch);
+    $err = curl_error($ch);
+    curl_close($ch);
+    return $res !== false && !$err;
+}
+?>

--- a/websocket/package.json
+++ b/websocket/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "websocket",
+  "version": "1.0.0",
+  "description": "coin websocket server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "socket.io": "^4.8.1"
+  }
+}

--- a/websocket/server.js
+++ b/websocket/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: { origin: '*' }
+});
+
+io.on('connection', (socket) => {
+  console.log('client connected', socket.id);
+  socket.on('join', (userId) => {
+    socket.join(String(userId));
+  });
+});
+
+app.use(express.json());
+
+// Endpoint for PHP to emit events
+app.post('/emit', (req, res) => {
+  const { userId, event, data } = req.body;
+  if (!event) return res.status(400).json({ error: 'event required' });
+  if (userId) {
+    io.to(String(userId)).emit(event, data);
+  } else {
+    io.emit(event, data);
+  }
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`WebSocket server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node socket server and helper scripts
- emit real-time events from order and data endpoints
- include socket client on the user dashboard
- provide PHP helper for sending events
- ignore WebSocket build files

## Testing
- `node websocket/server.js` *(manual start; server logs WebSocket startup)*
- `php -l utils/socket.php`
- `php -l php/market_order.php`
- `php -l php/place_order.php`
- `php -l php/setter.php`
- `php -l php/notifyFrontend.php`


------
https://chatgpt.com/codex/tasks/task_e_6887ce83219c83329680eeaf17311754