### PR TITLE
Fix PDO unbuffered query error

### DIFF
--- a/config/db_connection.php
+++ b/config/db_connection.php
@@ -5,7 +5,9 @@ function db(): PDO {
         $dsn = 'mysql:host=localhost;dbname=coin_db;charset=utf8mb4';
         $pdo = new PDO($dsn, 'root', '', [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false
+            // Enable query buffering so multiple queries can run sequentially
+            // without explicitly consuming all previous results.
+            PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true
         ]);
     }
     return $pdo;


### PR DESCRIPTION
## Summary
- enable query buffering in `db_connection.php` so sequential queries don't conflict

## Testing
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_6887d9d970f88332bf340f2c7e65f9e5