### PR TITLE
Add batch script for cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To keep wallet values in sync with the market, schedule `cron_wallet_usd.php` as
 ```cron
 * * * * * php /path/to/cron_wallet_usd.php
 ```
+For Windows users, double-click `run_cron_jobs.bat` in the project root to execute all cron tasks manually.
 
 ### Order type
 

--- a/run_cron_jobs.bat
+++ b/run_cron_jobs.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Run all cron jobs for the Coin Dashboard project
+cd /d "%~dp0"
+
+php cron\cron_wallet_usd.php
+php cron\cron_process_orders.php


### PR DESCRIPTION
## Summary
- add `run_cron_jobs.bat` to execute all cron tasks
- document Windows batch usage in README

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6887e38f0e808332ba8e4102bb65f85f