### PR TITLE
Improve dashboard refresh responsiveness

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -11,6 +11,16 @@ userId = userId ? parseInt(userId) : null;
 let dashboardInitialized = false;
 let autoRefreshHandle = null;
 
+// Trigger immediate refresh on user interactions
+function triggerTurboRefresh() {
+    if (!userId) return;
+    fetchDashboardData();
+    fetchWallets();
+}
+['click', 'input', 'change', 'drop'].forEach(evt => {
+    document.addEventListener(evt, triggerTurboRefresh, true);
+});
+
 // Utility functions
 function parseDollar(str) {
     return parseFloat(String(str).replace(/[^0-9.-]+/g, '')) || 0;
@@ -352,7 +362,7 @@ function startAutoRefresh() {
         if (document.hidden || !userId) return;
         await fetchDashboardData();
         await fetchWallets();
-    }, 30000);
+    }, 1000);
 }
 
 function stopAutoRefresh() {


### PR DESCRIPTION
## Summary
- refresh user dashboard every second instead of every 30s
- trigger immediate data reload on user interactions

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887e79b03a48332aa95c0e58d791e96