### PR TITLE
Fix wallet table flicker

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -308,7 +308,9 @@ function updateWalletTable(wallets = []) {
         }
     });
 
-    Object.values(existingRows).forEach($row => $row.remove());
+    if (wallets.length > 0) {
+        Object.values(existingRows).forEach($row => $row.remove());
+    }
 }
 
 async function fetchWallets() {


### PR DESCRIPTION
## Summary
- avoid clearing wallet table when the wallet list is empty

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888405591c483328b12a91bd1081160