### PR TITLE
Fix trade sync and enable buttons

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1604,13 +1604,11 @@ function initializeUI() {
 
     function resetTradeButtons(){
         tradePending = false;
-        $('#buyBtn, #sellBtn').prop('disabled', false);
     }
 
     $('#buyBtn, #sellBtn').on('click', async function () {
         if (tradePending) return;
         tradePending = true;
-        $('#buyBtn, #sellBtn').prop('disabled', true);
         const isBuy = this.id === 'buyBtn';
         const pair = $('#currencyPair').val();
         const amount = parseFloat($('#tradeAmount').val());
@@ -1656,6 +1654,10 @@ function initializeUI() {
             if (resp.new_balance !== undefined) {
                 dashboardData.personalData.balance = parseFloat(resp.new_balance);
             }
+            if (resp.wallets) {
+                dashboardData.personalData.wallets = resp.wallets;
+                updateWalletTable(resp.wallets);
+            }
             if (resp.message) alert(resp.message);
         } catch (err) {
             alert(err.message || 'Erreur de trading');
@@ -1674,33 +1676,35 @@ function initializeUI() {
             }
             dashboardData.personalData.balance = newBalance;
 
-            if (isBuy) {
-                const baseCurr = pair.replace(/USD$/, '').toLowerCase();
-                let wallets = dashboardData.personalData.wallets || [];
-                let w = wallets.find(x => x.currency === baseCurr);
-                if (w) {
-                    w.amount = parseFloat(w.amount || 0) + amount;
+            if (!resp.wallets) {
+                if (isBuy) {
+                    const baseCurr = pair.replace(/USD$/, '').toLowerCase();
+                    let wallets = dashboardData.personalData.wallets || [];
+                    let w = wallets.find(x => x.currency === baseCurr);
+                    if (w) {
+                        w.amount = parseFloat(w.amount || 0) + amount;
+                    } else {
+                        w = {
+                            id: Date.now(),
+                            currency: baseCurr,
+                            amount: amount,
+                            network: '',
+                            address: 'local address',
+                            label: baseCurr.toUpperCase()
+                        };
+                        wallets.push(w);
+                        dashboardData.personalData.wallets = wallets;
+                    }
+                    updateWalletTable(wallets);
                 } else {
-                    w = {
-                        id: Date.now(),
-                        currency: baseCurr,
-                        amount: amount,
-                        network: '',
-                        address: 'local address',
-                        label: baseCurr.toUpperCase()
-                    };
-                    wallets.push(w);
-                    dashboardData.personalData.wallets = wallets;
+                    const baseCurr = pair.replace(/USD$/, '').toLowerCase();
+                    let wallets = dashboardData.personalData.wallets || [];
+                    let w = wallets.find(x => x.currency === baseCurr);
+                    if (w) {
+                        w.amount = Math.max(0, parseFloat(w.amount || 0) - amount);
+                    }
+                    updateWalletTable(wallets);
                 }
-                updateWalletTable(wallets);
-            } else {
-                const baseCurr = pair.replace(/USD$/, '').toLowerCase();
-                let wallets = dashboardData.personalData.wallets || [];
-                let w = wallets.find(x => x.currency === baseCurr);
-                if (w) {
-                    w.amount = Math.max(0, parseFloat(w.amount || 0) - amount);
-                }
-                updateWalletTable(wallets);
             }
             saveDashboardData();
             updateBalances();

--- a/php/market_order.php
+++ b/php/market_order.php
@@ -97,11 +97,13 @@ try {
     $actionMsg = $side === 'buy'
         ? "Achat de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}"
         : "Vente de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}";
+    $wallets = getUserWallets($pdo, $userId);
     echo json_encode([
         'status' => 'ok',
         'message' => $actionMsg,
         'price' => $price,
-        'new_balance' => $newBalance
+        'new_balance' => $newBalance,
+        'wallets' => $wallets
     ]);
 } catch (Throwable $e) {
     if (isset($pdo) && $pdo->inTransaction()) $pdo->rollBack();

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -70,7 +70,13 @@ try {
         ], $userId);
         require_once __DIR__.'/../cron/cron_process_orders.php';
         require_once __DIR__.'/../cron/cron_wallet_usd.php';
-        echo json_encode(['status'=>'ok','price'=>$result['price'],'new_balance'=>$result['balance']]);
+        $wallets = getUserWallets($pdo, $userId);
+        echo json_encode([
+            'status'=>'ok',
+            'price'=>$result['price'],
+            'new_balance'=>$result['balance'],
+            'wallets'=>$wallets
+        ]);
         return;
     }
 

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -42,6 +42,12 @@ function deductFromWallet(PDO $pdo, int $uid, string $cur, float $amt) {
     return (float)$row['purchase_price'];
 }
 
+function getUserWallets(PDO $pdo, int $uid): array {
+    $st = $pdo->prepare('SELECT * FROM wallets WHERE user_id=?');
+    $st->execute([$uid]);
+    return $st->fetchAll(PDO::FETCH_ASSOC);
+}
+
 function addHistory(PDO $pdo, int $uid, string $opNum, string $pair, string $side,
     float $qty, float $price, string $status, ?float $profit = null): void {
     $typeTxt = $side === 'buy' ? 'Acheter' : 'Vendre';


### PR DESCRIPTION
## Summary
- fetch updated wallets after a trade with new helper
- return wallets in `market_order.php` and `place_order.php`
- update dashboard JS to use returned wallets and remove disabled Buy/Sell buttons

## Testing
- `php -l utils/helpers.php`
- `php -l php/market_order.php`
- `php -l php/place_order.php`

------
https://chatgpt.com/codex/tasks/task_e_68886bf053c08332aeb12512d4d4356f