### PR TITLE
Fix duplicate order persistence

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1538,7 +1538,9 @@ function initializeUI() {
             };
             dashboardData.tradingHistory.unshift(order);
         }
-        saveDashboardData();
+        // The backend already saved the completed trade and pushed the
+        // updated data. Simply refresh the UI without re-saving to avoid
+        // duplicate records.
         renderTradingHistory();
     };
 
@@ -1549,7 +1551,8 @@ function initializeUI() {
             const order = dashboardData.tradingHistory[idx];
             order.statut = 'annule';
             order.statutClass = 'bg-danger';
-            saveDashboardData();
+            // Avoid persisting the same order twice; the backend already
+            // recorded the cancellation.
             renderTradingHistory();
         }
     };


### PR DESCRIPTION
## Summary
- prevent client from persisting orders again when they are filled or cancelled

## Testing
- `node -c js/updatePrices.js`
- `php -l php/place_order.php`
- `php -l php/market_order.php`


------
https://chatgpt.com/codex/tasks/task_e_688911c816288332ab6c279fffdbee16