### PR TITLE
Add PnL calculation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,30 @@ The old WebSocket server has been removed. The dashboard now relies on a
 long polling endpoint (`php/long_poll.php`). Client-side JavaScript keeps
 sending background requests and immediately processes any returned events to
 update balances, wallets or orders without reloading the page.
+
+## Profit/Loss calculation
+
+Use the executed trade price, not the candle price, to determine profit or loss.
+The basic formula for closing a long position is:
+
+```
+(sell price - average buy price) * quantity sold
+```
+
+For short selling the logic is reversed:
+
+```
+(sell price - buy price) * quantity
+```
+
+`utils/pnl.php` contains helper functions implementing these rules. The
+`calculate_average_buy_price()` function builds the weighted average from a list
+of prior buy trades, while `profit_loss_long()` and `profit_loss_short()` return
+the resulting PnL. A small JavaScript version lives in `js/pnl.js` for client
+side use. Example usage in PHP:
+
+```php
+$avg = calculate_average_buy_price($previousBuys);
+$profit = profit_loss_long($executedSellPrice, $avg, $soldQty);
+```
+

--- a/js/pnl.js
+++ b/js/pnl.js
@@ -1,0 +1,23 @@
+/**
+ * Utility helpers for client-side PnL calculations.
+ */
+export function averageBuyPrice(buys) {
+    let cost = 0;
+    let qty = 0;
+    for (const t of buys) {
+        const q = parseFloat(t.quantity) || 0;
+        const p = parseFloat(t.price) || 0;
+        cost += p * q;
+        qty += q;
+    }
+    return qty > 0 ? cost / qty : 0;
+}
+
+export function profitLossLong(sellPrice, avgBuyPrice, qtySold) {
+    return (sellPrice - avgBuyPrice) * qtySold;
+}
+
+export function profitLossShort(buyPrice, sellPrice, qty) {
+    return (sellPrice - buyPrice) * qty;
+}
+

--- a/sql/pnl_triggers.sql
+++ b/sql/pnl_triggers.sql
@@ -1,0 +1,25 @@
+DELIMITER //
+-- Automatically compute profit/loss whenever a trade is recorded
+CREATE TRIGGER trg_trades_before_insert
+BEFORE INSERT ON trades
+FOR EACH ROW
+BEGIN
+  DECLARE avg_price DECIMAL(20,10);
+  DECLARE base_currency VARCHAR(10);
+  SET base_currency = SUBSTRING_INDEX(NEW.pair,'/',1);
+  IF NEW.side = 'sell' THEN
+    SELECT purchase_price INTO avg_price
+    FROM wallets
+    WHERE user_id = NEW.user_id AND currency = LOWER(base_currency)
+    LIMIT 1;
+    IF avg_price IS NULL THEN
+      SET avg_price = 0;
+    END IF;
+    SET NEW.profit_loss = (NEW.price - avg_price) * NEW.quantity;
+  ELSE
+    -- buy trade (long position open), no immediate profit
+    SET NEW.profit_loss = 0;
+  END IF;
+END//
+DELIMITER ;
+

--- a/utils/pnl.php
+++ b/utils/pnl.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Utility functions for profit/loss calculations.
+ */
+
+/**
+ * Calculate the weighted average buy price from an array of prior buy trades.
+ * Each trade should contain 'price' and 'quantity' keys.
+ */
+function calculate_average_buy_price(array $buyTrades): float {
+    $totalCost = 0.0;
+    $totalQty = 0.0;
+    foreach ($buyTrades as $t) {
+        $qty = isset($t['quantity']) ? (float)$t['quantity'] : 0.0;
+        $price = isset($t['price']) ? (float)$t['price'] : 0.0;
+        $totalCost += $price * $qty;
+        $totalQty += $qty;
+    }
+    return $totalQty > 0 ? $totalCost / $totalQty : 0.0;
+}
+
+/**
+ * Profit/loss when closing a long position.
+ */
+function profit_loss_long(float $sellPrice, float $avgBuyPrice, float $qtySold): float {
+    return ($sellPrice - $avgBuyPrice) * $qtySold;
+}
+
+/**
+ * Profit/loss when closing a short position.
+ */
+function profit_loss_short(float $buyPrice, float $sellPrice, float $qty): float {
+    return ($sellPrice - $buyPrice) * $qty;
+}
+
+


### PR DESCRIPTION
## Summary
- add PHP utilities for calculating average buy price and profit/loss
- provide equivalent JavaScript helpers
- include example SQL trigger to auto-compute trade PnL
- document how profit/loss is calculated

## Testing
- `php -l utils/pnl.php`

------
https://chatgpt.com/codex/tasks/task_e_688930b69b948332b28ac427ed4436d4