### PR TITLE
Fix order processing logic and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ occurs:
 ```
 For Windows users, double-click `run_cron_jobs.bat` in the project root to execute all cron tasks manually.
 
-### Order type
+### Order types
 
-Only market orders are supported. Trades are executed immediately at the current market price and recorded in the `trades` table.
+The platform supports a variety of order types. Market orders are executed immediately using the current price returned by Binance. Pending orders (limit, stop, stop‑limit, trailing stop, percentage based stop, time based stop and OCO) are stored in the `orders` table until the `cron_process_orders.php` task evaluates them.
 
 When querying Binance for live prices remember that pairs use the `USDT` quote currency. A pair like `ADA/USD` should be converted to `ADAUSDT` before requesting the price.
 

--- a/cron/cron_process_orders.php
+++ b/cron/cron_process_orders.php
@@ -15,17 +15,17 @@ foreach ($orders as $o) {
         case 'limit':
             if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
                 $pdo->beginTransaction();
-                $res = executeTrade($pdo, $o, $o['target_price']);
+                $res = executeTrade($pdo, $o, $price);
                 if ($res['ok']) {
                     $pdo->commit();
                     require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
+                    pushEvent('balance_updated',[ 'newBalance'=>$res['balance'] ],$o['user_id']);
                     pushEvent('wallet_updated',[],$o['user_id']);
-                    pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$o['target_price']],$o['user_id']);
+                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
                 } else {
                     $pdo->rollBack();
                 }
-                }
+            }
             break;
         case 'percentage_stop':
             $threshold = $o['trail_price'];
@@ -79,13 +79,13 @@ foreach ($orders as $o) {
         case 'oco':
             if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
                 $pdo->beginTransaction();
-                $res = executeTrade($pdo, $o, $o['target_price']);
+                $res = executeTrade($pdo, $o, $price);
                 if ($res['ok']) {
                     $pdo->commit();
                     require_once __DIR__.'/../utils/poll.php';
                     pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
                     pushEvent('wallet_updated',[],$o['user_id']);
-                    pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$o['target_price']],$o['user_id']);
+                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
                 } else {
                     $pdo->rollBack();
                 }
@@ -116,13 +116,13 @@ foreach ($orders as $o) {
             if ($o['status']=='triggered') {
                 if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
                     $pdo->beginTransaction();
-                    $res = executeTrade($pdo,$o,$o['target_price']);
+                    $res = executeTrade($pdo,$o,$price);
                     if ($res['ok']) {
                         $pdo->commit();
                         require_once __DIR__.'/../utils/poll.php';
                         pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
                         pushEvent('wallet_updated',[],$o['user_id']);
-                        pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$o['target_price']],$o['user_id']);
+                        pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
                     } else {
                         $pdo->rollBack();
                     }

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -30,6 +30,10 @@ try{
         exit;
     }
     $pdo->prepare('UPDATE orders SET status="cancelled" WHERE id=?')->execute([$orderId]);
+    if (!empty($order['related_order_id'])) {
+        $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=? AND status IN ('open','triggered')")
+            ->execute([$order['related_order_id']]);
+    }
     $price = isset($order['target_price']) ? $order['target_price'] : 0;
     addHistory($pdo,$userId,'T'.$orderId,$order['pair'],$order['side'],$order['quantity'],$price,'annule');
     $pdo->commit();


### PR DESCRIPTION
## Summary
- correct logic in `cron_process_orders.php` to use actual market price for filled orders
- remove stray brace and update push events
- cancel OCO counterpart when cancelling an order
- document advanced order types in README

## Testing
- `php -l cron/cron_process_orders.php`
- `php -l php/cancel_order.php`
- `find php -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find cron -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68893989a86083329f69499f3c3aea79