### PR TITLE
Add CryptoCompare historical price endpoint and pair validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,14 @@ $avg = calculate_average_buy_price($previousBuys);
 $profit = profit_loss_long($executedSellPrice, $avg, $soldQty);
 ```
 
+## Historical prices
+
+The helper function `getHistoricalPrice()` fetches the closing price of a
+currency pair at a specific Unix timestamp from the public CryptoCompare API.
+Use the `php/historical_price.php` endpoint with `pair` and `timestamp`
+parameters to retrieve the value:
+
+```sh
+curl 'php/historical_price.php?pair=BTC/USD&timestamp=1609459200'
+```
+

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1391,6 +1391,7 @@ function initializeUI() {
     }
 
     let currentPrice = 0;
+    let currentPricePair = '';
     let priceChange = 0;
 
     function renderTradingHistory() {
@@ -1432,6 +1433,7 @@ function initializeUI() {
     }
 
     function fetchPrice(pair) {
+        currentPricePair = pair;
         const symbol = getBinanceSymbol(pair);
         fetch(`https://api.binance.com/api/v3/ticker/24hr?symbol=${symbol}`)
             .then(r => r.json())
@@ -1623,6 +1625,11 @@ function initializeUI() {
         tradePending = true;
         const isBuy = this.id === 'buyBtn';
         const pair = $('#currencyPair').val();
+        if (pair !== currentPricePair) {
+            alert('Le prix affiché ne correspond pas à la paire sélectionnée. Veuillez patienter pour la mise à jour du prix.');
+            resetTradeButtons();
+            return;
+        }
         const amount = parseFloat($('#tradeAmount').val());
         if (!amount) {
             alert('Veuillez entrer un montant valide');

--- a/php/historical_price.php
+++ b/php/historical_price.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function($s,$m,$f,$l){throw new ErrorException($m,0,$s,$f,$l);});
+
+try {
+    if($_SERVER['REQUEST_METHOD'] !== 'GET') {
+        http_response_code(405);
+        echo json_encode(['status'=>'error','message'=>'Method not allowed']);
+        exit;
+    }
+    $pair = isset($_GET['pair']) ? $_GET['pair'] : '';
+    $timestamp = isset($_GET['timestamp']) ? (int)$_GET['timestamp'] : 0;
+    if(!$pair || !$timestamp){
+        http_response_code(400);
+        echo json_encode(['status'=>'error','message'=>'Missing parameters']);
+        exit;
+    }
+    require_once __DIR__.'/../utils/helpers.php';
+    $price = getHistoricalPrice($pair, $timestamp);
+    echo json_encode(['status'=>'ok','price'=>$price]);
+} catch(Throwable $e){
+    http_response_code(500);
+    echo json_encode(['status'=>'error','message'=>$e->getMessage()]);
+}
+?>

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -9,6 +9,27 @@ function getLivePrice(string $pair): float {
     return isset($data['price']) ? (float)$data['price'] : 0.0;
 }
 
+/**
+ * Fetch the historical closing price for a currency pair from CryptoCompare.
+ * The timestamp should be a Unix epoch (seconds).
+ * Returns 0 on failure.
+ */
+function getHistoricalPrice(string $pair, int $timestamp): float {
+    [$base, $quote] = explode('/', strtoupper($pair));
+    // CryptoCompare expects USD rather than USDT
+    if ($quote === 'USDT') {
+        $quote = 'USD';
+    }
+    $url = sprintf(
+        'https://min-api.cryptocompare.com/data/pricehistorical?fsym=%s&tsyms=%s&ts=%d',
+        urlencode($base), urlencode($quote), $timestamp
+    );
+    $json = @file_get_contents($url);
+    if ($json === false) return 0.0;
+    $data = json_decode($json, true);
+    return isset($data[$base][$quote]) ? (float)$data[$base][$quote] : 0.0;
+}
+
 function addToWallet(PDO $pdo, int $uid, string $cur, float $amt, float $price): void {
     $cur = strtolower($cur);
     $st = $pdo->prepare('SELECT amount,purchase_price FROM wallets WHERE user_id=? AND currency=? FOR UPDATE');


### PR DESCRIPTION
## Summary
- support fetching historical prices using CryptoCompare
- expose new `php/historical_price.php` endpoint
- validate the selected currency pair matches the displayed price before trading
- document historical pricing endpoint

## Testing
- `php -l php/historical_price.php`
- `php -l utils/helpers.php`
- `node --check js/updatePrices.js`

------
https://chatgpt.com/codex/tasks/task_e_688998063f108332a671034a8f69c747