### PR TITLE
Improve trading history amount precision

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -42,6 +42,13 @@ function formatCrypto(num) {
     });
 }
 
+function formatCryptoFixed(num, digits = 5) {
+    return Number(num).toLocaleString('en-US', {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits
+    });
+}
+
 function escapeHtml(str) {
     return String(str)
         .replace(/&/g, '&amp;')
@@ -1410,7 +1417,7 @@ function initializeUI() {
                         <td>${escapeHtml(trade.temps)}</td>
                         <td>${escapeHtml(trade.paireDevises)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutTypeClass)}">${escapeHtml(trade.type)}</span></td>
-                        <td>${formatCrypto(trade.montant)} ${escapeHtml((trade.paireDevises||'').split('/')[0])}</td>
+                        <td>${formatCryptoFixed(trade.montant)} ${escapeHtml((trade.paireDevises||'').split('/')[0])}</td>
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>


### PR DESCRIPTION
## Summary
- add formatCryptoFixed for consistent decimal places
- display trading history amounts with 5 decimals

## Testing
- `node -e "require('./js/updatePrices.js')"` *(fails: document not defined but confirms syntax)*

------
https://chatgpt.com/codex/tasks/task_e_6889a26e002c8332a2efdd96cc837001