### PR TITLE
Add currency toggle and quick price fill

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -217,7 +217,7 @@
 <label class="form-label" for="tradeAmount">Montant</label>
 <div class="input-group">
 <input class="form-control" name="tradeAmount" id="tradeAmount" min="0.01" placeholder="Entrez le montant" required="" step="0.01" type="number"/>
-<span class="input-group-text">USD</span>
+<span class="input-group-text" id="tradeAmountCurrency">USD</span>
 </div>
 <div class="form-text">Solde disponible : <span class="fw-bold" id="soldeintrade">---</span>
 </div>
@@ -236,15 +236,21 @@
 <div class="mb-3" id="stopPriceDiv" style="display: none;">
 <label class="form-label" for="stopPrice">Prix stop</label>
 <div class="input-group">
-<input class="form-control" name="stopPrice" id="stopPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
-<span class="input-group-text">USD</span>
+  <input class="form-control" name="stopPrice" id="stopPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
+  <span class="input-group-text">USD</span>
+  <button class="btn btn-outline-secondary" id="useCurrentStopPrice" type="button">
+    <i class="fas fa-bolt"></i>
+  </button>
 </div>
 </div>
 <div class="mb-3" id="limitPriceDiv" style="display: none;">
 <label class="form-label" for="limitPrice">Prix limite</label>
 <div class="input-group">
-<input class="form-control" name="limitPrice" id="limitPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
-<span class="input-group-text">USD</span>
+  <input class="form-control" name="limitPrice" id="limitPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
+  <span class="input-group-text">USD</span>
+  <button class="btn btn-outline-secondary" id="useCurrentLimitPrice" type="button">
+    <i class="fas fa-bolt"></i>
+  </button>
 </div>
 <div class="mb-3" id="stopLimitPriceDiv" style="display: none;">
 <label class="form-label" for="stopLimitPrice">Prix limite du stop</label>

--- a/script.js
+++ b/script.js
@@ -17,5 +17,44 @@ $(function() {
         $('#takeProfitDiv').toggle(this.checked);
     });
 
+    function updateTradeAmountCurrency() {
+        const pairText = $('#currencyPair option:selected').text() || '';
+        const parts = pairText.split('/');
+        const base = parts[0] || 'BTC';
+        const quote = parts[1] || 'USD';
+        const $span = $('#tradeAmountCurrency');
+        $span.text(quote);
+        $span.data({ base, quote, show: 'quote' });
+    }
+
+    $('#tradeAmountCurrency').on('click', function() {
+        const $el = $(this);
+        const show = $el.data('show');
+        const base = $el.data('base');
+        const quote = $el.data('quote');
+        if (show === 'quote') {
+            $el.text(base);
+            $el.data('show', 'base');
+        } else {
+            $el.text(quote);
+            $el.data('show', 'quote');
+        }
+    });
+
+    $('#currencyPair').on('change', updateTradeAmountCurrency);
+
+    $('#useCurrentLimitPrice').on('click', function() {
+        if (typeof currentPrice !== 'undefined') {
+            $('#limitPrice').val(currentPrice.toFixed(2));
+        }
+    });
+
+    $('#useCurrentStopPrice').on('click', function() {
+        if (typeof currentPrice !== 'undefined') {
+            $('#stopPrice').val(currentPrice.toFixed(2));
+        }
+    });
+
     updateStopLossFields();
+    updateTradeAmountCurrency();
 });


### PR DESCRIPTION
## Summary
- toggle the currency label of trade amount between base and quote on click
- allow setting stop/limit price fields to the current price via button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6889ab9203a483329c540aa4547ebdf6