### PR TITLE
Add order confirmation alert for pending orders

### DIFF
--- a/php/place_order.php
+++ b/php/place_order.php
@@ -128,7 +128,13 @@ try {
     require_once __DIR__.'/../cron/cron_process_orders.php';
     require_once __DIR__.'/../cron/cron_wallet_usd.php';
 
-    echo json_encode(['status'=>'ok','order_id'=>$id]);
+    [$base] = explode('/', strtoupper($pair));
+    $typeLabel = str_replace('_', ' ', $type);
+    $actionMsg = $side === 'buy'
+        ? "Ordre {$typeLabel} d'achat de {$qty} {$base} enregist\xC3\xA9"
+        : "Ordre {$typeLabel} de vente de {$qty} {$base} enregist\xC3\xA9";
+
+    echo json_encode(['status' => 'ok', 'order_id' => $id, 'message' => $actionMsg]);
 } catch(Throwable $e){
     if(isset($pdo)&&$pdo->inTransaction()) $pdo->rollBack();
     http_response_code(500);


### PR DESCRIPTION
## Summary
- notify client when a pending order is placed
- frontend already displays `resp.message` so all order types now trigger an alert like market orders

## Testing
- `php -l php/place_order.php`
- `find php -name '*.php' -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6889acc5a2f8833285940b24aca1711a