### PR TITLE
Fix price buttons to use current price text

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,17 +79,16 @@ $(function() {
     $('#tradeAmount').on('input', updateTradeAmountEquivalent);
 
     $('#useCurrentLimitPrice').on('click', function() {
-        const changeText = $('#priceChange').text();
-        const changeNum = parseFloat(changeText);
-        if (!isNaN(changeNum)) {
-            $('#limitPrice').val(changeNum);
-        } else {
-            $('#limitPrice').val(changeText);
+        const priceText = $('#currentPrice').text().replace(/[^0-9.-]/g, '');
+        const priceNum = parseFloat(priceText);
+        if (!isNaN(priceNum)) {
+            $('#limitPrice').val(priceNum.toFixed(2));
         }
     });
 
     $('#useCurrentStopPrice').on('click', function() {
-        const priceNum = parseFloat(currentPrice);
+        const priceText = $('#currentPrice').text().replace(/[^0-9.-]/g, '');
+        const priceNum = parseFloat(priceText);
         if (!isNaN(priceNum)) {
             $('#stopPrice').val(priceNum.toFixed(2));
         }


### PR DESCRIPTION
## Summary
- ensure the limit/stop price shortcuts use the current displayed price

## Testing
- `find php -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_688a9e937f988332a81c26012864c977