### PR TITLE
Support USD input for trades

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -216,7 +216,7 @@
 <div class="mb-3">
 <label class="form-label" for="tradeAmount">Montant</label>
 <div class="input-group">
-<input class="form-control" name="tradeAmount" id="tradeAmount" min="0.01" placeholder="Entrez le montant" required="" step="0.01" type="number"/>
+<input class="form-control" name="tradeAmount" id="tradeAmount" placeholder="Entrez le montant" required="" step="0.01" type="number"/>
 <span class="input-group-text" id="tradeAmountCurrency" style="cursor: pointer;">
   <i class="fas fa-exchange-alt me-1"></i>USD
 </span>

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1637,7 +1637,13 @@ function initializeUI() {
             resetTradeButtons();
             return;
         }
-        const amount = parseFloat($('#tradeAmount').val());
+        let amount = parseFloat($('#tradeAmount').val());
+        if ($('#tradeAmountCurrency').data('show') === 'quote') {
+            const p = parseFloat(currentPrice);
+            if (!isNaN(p)) {
+                amount = amount / p;
+            }
+        }
         if (!amount) {
             alert('Veuillez entrer un montant valide');
             resetTradeButtons();


### PR DESCRIPTION
## Summary
- remove minimum amount restriction on trade input
- convert USD amount back to coin before placing an order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688aa55ddac8833285f5c9c476f016eb