### PR TITLE
Fix pair switching inconsistency

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1442,17 +1442,20 @@ function initializeUI() {
     }
 
     function fetchPrice(pair) {
+        const fetchFor = pair;
         currentPricePair = pair;
         const symbol = getBinanceSymbol(pair);
         fetch(`https://api.binance.com/api/v3/ticker/24hr?symbol=${symbol}`)
             .then(r => r.json())
             .then(info => {
+                if (currentPricePair !== fetchFor) return; // ignore stale response
                 currentPrice = parseFloat(info.lastPrice);
                 priceChange = parseFloat(info.priceChangePercent);
                 updatePriceUI();
                 // Market orders execute immediately; no pending conditions
             })
             .catch(() => {
+                if (currentPricePair !== fetchFor) return;
                 $('#currentPrice').text('N/A');
                 $('#priceChange').text('-');
             });


### PR DESCRIPTION
## Summary
- avoid stale ticker updates when switching currency pairs

## Testing
- `node --check js/updatePrices.js`

------
https://chatgpt.com/codex/tasks/task_e_688aebc446908332bf731f3bcbe0eee8