### PR TITLE
Verify selected pair before sending orders

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1655,6 +1655,11 @@ function initializeUI() {
             resetTradeButtons();
             return;
         }
+        if ($('#currencyPair').val() !== pairVal) {
+            alert("La paire sélectionnée a changé. Veuillez vérifier avant d'envoyer l'ordre.");
+            resetTradeButtons();
+            return;
+        }
         let amount = parseFloat($('#tradeAmount').val());
         if ($('#tradeAmountCurrency').data('show') === 'quote') {
             const p = parseFloat(currentPrice);
@@ -1836,6 +1841,10 @@ function initializeUI() {
         if(!userId) return;
         const pairVal = selectedPairVal;
         const pairText = selectedPairText;
+        if ($('#currencyPair').val() !== pairVal) {
+            alert("La paire sélectionnée a changé. Veuillez vérifier avant d'envoyer l'ordre.");
+            return;
+        }
         const qty = parseFloat($('#tradeAmount').val()) || 0;
         const typeMap = { price:'stop', percentage:'percentage_stop', time:'time_stop', trailing:'trailing_stop' };
         const slType = $('#stopLossType').val();


### PR DESCRIPTION
## Summary
- ensure the order uses the currently selected pair in the UI before sending requests
- prevent stop loss orders from using a stale pair

## Testing
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_688af034b554833283daa556d82bd61b