### PR TITLE
Ensure notification timestamps use server time

### DIFF
--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -8,6 +8,19 @@ try {
     require_once __DIR__.'/../config/db_connection.php';
     $pdo = db();
 
+    function formatTimeAgoFromDate($dateStr) {
+        $ts = strtotime($dateStr);
+        if (!$ts) return '';
+        $diff = time() - $ts;
+        if ($diff < 60) return "À l'instant";
+        $mins = floor($diff / 60);
+        if ($mins < 60) return 'Il y a ' . $mins . ' minute' . ($mins > 1 ? 's' : '');
+        $hours = floor($diff / 3600);
+        if ($hours < 24) return 'Il y a ' . $hours . ' heure' . ($hours > 1 ? 's' : '');
+        $days = floor($diff / 86400);
+        return 'Il y a ' . $days . ' jour' . ($days > 1 ? 's' : '');
+    }
+
 $adminId = null;
 
 session_start();
@@ -116,6 +129,9 @@ if ($userIds) {
     $stmt = $pdo->prepare($sql);
     $stmt->execute($userIds);
     $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($notifications as &$n) {
+        $n['time'] = formatTimeAgoFromDate($n['time']);
+    }
 }
 $result['notifications'] = $notifications;
 

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -8,19 +8,6 @@ try {
     require_once __DIR__.'/../config/db_connection.php';
     $pdo = db();
 
-    function formatTimeAgoFromDate($dateStr) {
-        $ts = strtotime($dateStr);
-        if (!$ts) return '';
-        $diff = time() - $ts;
-        if ($diff < 60) return "À l'instant";
-        $mins = floor($diff / 60);
-        if ($mins < 60) return 'Il y a ' . $mins . ' minute' . ($mins > 1 ? 's' : '');
-        $hours = floor($diff / 3600);
-        if ($hours < 24) return 'Il y a ' . $hours . ' heure' . ($hours > 1 ? 's' : '');
-        $days = floor($diff / 86400);
-        return 'Il y a ' . $days . ' jour' . ($days > 1 ? 's' : '');
-    }
-
     function deleteUserData(PDO $pdo, int $userId) {
         $tables = [
             'wallets',
@@ -332,7 +319,7 @@ try {
                         if ($oldStatus !== 'complet' && $status === 'complet') {
                             // deposit completion adjustments handled by triggers
 
-                            $timeAgo = formatTimeAgoFromDate($row['date']);
+                            $timeNow = date('Y-m-d H:i:s');
                             $msgAmount = number_format($amount, 0, '.', ' ') . ' $';
                             $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
                                 ->execute([
@@ -340,7 +327,7 @@ try {
                                     'success',
                                     'Dépôt réussi',
                                     "Un montant de $msgAmount a été déposé avec succès.",
-                                    $timeAgo,
+                                    $timeNow,
                                     'alert-success'
                                 ]);
                         } elseif ($oldStatus === 'complet' && $status !== 'complet') {
@@ -350,7 +337,7 @@ try {
                         if ($oldStatus !== 'complet' && $status === 'complet') {
                             // withdrawal completion handled by trigger trg_retraits_after_update
 
-                            $timeAgo = formatTimeAgoFromDate($row['date']);
+                            $timeNow = date('Y-m-d H:i:s');
                             $msgAmount = number_format($amount, 0, '.', ' ') . ' $';
                             $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
                                 ->execute([
@@ -358,7 +345,7 @@ try {
                                     'success',
                                     'Retrait approuvé',
                                     "Votre retrait de $msgAmount a été approuvé.",
-                                    $timeAgo,
+                                    $timeNow,
                                     'alert-success'
                                 ]);
                         } elseif ($oldStatus === 'complet' && $status !== 'complet') {
@@ -378,7 +365,7 @@ try {
         if (!$date) { throw new Exception('Missing date'); }
         $stmt = $pdo->query('SELECT user_id FROM personal_data');
         $userIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
-        $timeAgo = formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+        $timeNow = date('Y-m-d H:i:s');
         $insert = $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)');
         foreach ($userIds as $uid) {
             $insert->execute([
@@ -386,7 +373,7 @@ try {
                 'info',
                 'Mise à jour du système',
                 "Le système sera mis à jour le $date.",
-                $timeAgo,
+                $timeNow,
                 'alert-info'
             ]);
         }
@@ -407,14 +394,14 @@ try {
             $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')
                 ->execute([$uid, $val]);
             if ($status === 'approved') {
-                $timeAgo = formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+                $timeNow = date('Y-m-d H:i:s');
                 $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
                     ->execute([
                         $uid,
                         'kyc',
                         'Vérification approuvée',
                         "Votre vérification d'identité a été approuvée.",
-                        $timeAgo,
+                        $timeNow,
                         'alert-success'
                     ]);
             }

--- a/php/getter.php
+++ b/php/getter.php
@@ -16,10 +16,27 @@ function fetchAll($pdo, $sql, $params = []) {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+function formatTimeAgoFromDate($dateStr) {
+    $ts = strtotime($dateStr);
+    if (!$ts) return '';
+    $diff = time() - $ts;
+    if ($diff < 60) return "À l'instant";
+    $mins = floor($diff / 60);
+    if ($mins < 60) return 'Il y a ' . $mins . ' minute' . ($mins > 1 ? 's' : '');
+    $hours = floor($diff / 3600);
+    if ($hours < 24) return 'Il y a ' . $hours . ' heure' . ($hours > 1 ? 's' : '');
+    $days = floor($diff / 86400);
+    return 'Il y a ' . $days . ' jour' . ($days > 1 ? 's' : '');
+}
+
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
 $bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
+$notifications = fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC LIMIT 100', [$userId]);
+foreach ($notifications as &$n) {
+    $n['time'] = formatTimeAgoFromDate($n['time']);
+}
 
 $kycRows = fetchAll($pdo, 'SELECT status,created_at FROM kyc WHERE user_id = ? ORDER BY created_at DESC LIMIT 20', [$userId]);
 $kycStatus = '0';
@@ -37,7 +54,7 @@ $data = [
     'personalData' => $personal,
     'wallets' => fetchAll($pdo, 'SELECT * FROM wallets WHERE user_id = ?', [$userId]),
     'transactions' => fetchAll($pdo, 'SELECT operationNumber,type,amount,date,status,statusClass FROM transactions WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
-    'notifications' => fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC LIMIT 100', [$userId]),
+    'notifications' => $notifications,
     'deposits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'retraits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'tradingHistory' => array_map(function($r){

--- a/php/kyc_admin.php
+++ b/php/kyc_admin.php
@@ -5,18 +5,6 @@ try{
     require_once __DIR__.'/../config/db_connection.php';
     $pdo = db();
 
-    function formatTimeAgoFromDate($dateStr){
-        $ts=strtotime($dateStr);
-        if(!$ts) return '';
-        $diff=time()-$ts;
-        if($diff<60) return "À l'instant";
-        $mins=floor($diff/60);
-        if($mins<60) return 'Il y a '.$mins.' minute'.($mins>1?'s':'');
-        $hours=floor($diff/3600);
-        if($hours<24) return 'Il y a '.$hours.' heure'.($hours>1?'s':'');
-        $days=floor($diff/86400);
-        return 'Il y a '.$days.' jour'.($days>1?'s':'');
-    }
     session_start();
     $adminId=$_SESSION['admin_id']??null;
     if(!$adminId){
@@ -66,14 +54,14 @@ try{
             $val=$status==='approved'?1:0;
             $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
             if($status==='approved'){
-                $timeAgo=formatTimeAgoFromDate(date('Y-m-d H:i:s'));
+                $timeNow = date('Y-m-d H:i:s');
                 $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')
                     ->execute([
                         $uid,
                         'kyc',
                         'Vérification approuvée',
                         "Votre vérification d'identité a été approuvée.",
-                        $timeAgo,
+                        $timeNow,
                         'alert-success'
                     ]);
             }


### PR DESCRIPTION
## Summary
- Store notifications with precise server timestamps instead of static "time ago" strings during deposits, withdrawals, broadcasts and KYC updates.
- Compute human-friendly "time ago" values on retrieval in user and admin getters to reflect current server time.

## Testing
- `php -l php/admin_setter.php`
- `php -l php/kyc_admin.php`
- `php -l php/getter.php`
- `php -l php/admin_getter.php`


------
https://chatgpt.com/codex/tasks/task_e_688e206e297c8332926062ed1156b898