### PR TITLE
feat: add profile picture column

### DIFF
--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -38,7 +38,8 @@ CREATE TABLE personal_data (
     userIban TEXT,
     userSwiftCode TEXT,
     note TEXT,
-    linked_to_id INTEGER
+    linked_to_id INTEGER,
+    profile_pic MEDIUMTEXT
 ) ENGINE=InnoDB;
 
 CREATE TABLE wallets (

--- a/sql/insertdata.sql
+++ b/sql/insertdata.sql
@@ -1,15 +1,23 @@
 INSERT INTO admins_agents (email, password, is_admin, created_by)
 VALUES ('admin@scampia.io', 'c1de8b176818ec85532879c60030aedd', 1, NULL);
 
-INSERT INTO personal_data VALUES (
-1, 3500, 3000, 1200, '10',
-'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2',
-'c1de8b176818ec85532879c60030aedd', 'Fort', '90%',
-'0', '0', '0', '1', '0',
-'41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000',
-'2025-06-11', 'ca', '2025-01-01',
-'Bank of Earth', 'Ahmed Kouraychi',
-'ACC123456', 'IBAN123456', 'SWIFT123', '', 1
+INSERT INTO personal_data (
+    user_id, balance, totalDepots, totalRetraits, nbTransactions,
+    fullName, compteverifie, compteverifie01, niveauavance,
+    passwordHash, passwordStrength, passwordStrengthBar,
+    emailNotifications, smsNotifications, loginAlerts, transactionAlerts,
+    twoFactorAuth, emailaddress, address, phone, dob, nationality, created_at,
+    userBankName, userAccountName, userAccountNumber, userIban, userSwiftCode,
+    note, linked_to_id, profile_pic
+) VALUES (
+    1, 3500, 3000, 1200, '10',
+    'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2',
+    'c1de8b176818ec85532879c60030aedd', 'Fort', '90%',
+    '0', '0', '0', '1', '0',
+    '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000',
+    '2025-06-11', 'ca', '2025-01-01',
+    'Bank of Earth', 'Ahmed Kouraychi',
+    'ACC123456', 'IBAN123456', 'SWIFT123', '', 1, NULL
 );
 
 INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES


### PR DESCRIPTION
## Summary
- add `profile_pic` column to `personal_data`
- include new column in seed data

## Testing
- `php -l php/profile_pic_upload.php`
- `mysql -e "SELECT 1;"` *(fails: Can't connect to local MySQL server)*


------
https://chatgpt.com/codex/tasks/task_e_688e28890e8c8332a30de197bf025a7f