### PR TITLE
Use placeholder profile images

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -163,10 +163,15 @@
                         <div class="d-flex align-items-center">
                             <span class="me-3">Bienvenue, Administrateur</span>
                             <div class="dropdown">
-                                <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-                                    <i class="bi bi-person-circle"></i>
+                                <button class="btn btn-outline-secondary dropdown-toggle d-flex align-items-center" type="button" data-bs-toggle="dropdown" id="adminAccountDropdown" aria-expanded="false">
+                                    <img alt="Image Utilisateur" class="rounded-circle" src="https://via.placeholder.com/40" style="width: 40px; height: 40px;">
                                 </button>
-                                <ul class="dropdown-menu">
+                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="adminAccountDropdown" style="min-width: 250px;">
+                                    <li class="dropdown-header text-center">
+                                        <img alt="Image Utilisateur" class="rounded-circle mb-2" src="https://via.placeholder.com/60" style="width: 60px; height: 60px;"/>
+                                        <div class="fw-bold">Administrateur</div>
+                                    </li>
+                                    <li><hr class="dropdown-divider"/></li>
                                     <li><a class="dropdown-item" href="#" id="settingsLink"><i class="bi bi-gear me-2"></i>Paramètres</a></li>
                                     <li><a class="dropdown-item" href="#" id="logoutLink"><i class="bi bi-box-arrow-right me-2"></i>Déconnexion</a></li>
                                 </ul>

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -114,8 +114,8 @@
 </ul>
 </div>
 <div class="dropdown">
-<button aria-expanded="false" class="btn btn-sm btn-outline-secondary dropdown-toggle ms-2" data-bs-toggle="dropdown" id="accountDropdown" type="button">
-<i class="fas fa-user-circle" style="margin-right: 8px;"></i>Mon compte </button>
+<button aria-expanded="false" class="btn btn-sm btn-outline-secondary dropdown-toggle ms-2 d-flex align-items-center" data-bs-toggle="dropdown" id="accountDropdown" type="button">
+<img alt="Image Utilisateur" class="rounded-circle me-2" src="https://via.placeholder.com/40" style="width: 40px; height: 40px;"/>Mon compte </button>
 <ul aria-labelledby="accountDropdown" class="dropdown-menu dropdown-menu-end" style="min-width: 250px;">
 <li class="dropdown-header text-center">
 <img alt="Image Utilisateur" class="rounded-circle mb-2" src="https://via.placeholder.com/60" style="width: 60px; height: 60px;"/>


### PR DESCRIPTION
## Summary
- display placeholder profile picture in user account dropdown
- show the same profile image in admin account menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2b8117a48332abb54e84b17ffdb5