### PR TITLE
Only show linked_to_id field to admins when editing users

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1477,6 +1477,7 @@
                 const hiddenFields = ['compteverifie','compteverifie01','niveauavance','passwordStrength','passwordStrengthBar','passwordHash'];
                 Object.keys(pd).forEach(key => {
                     if (key === 'user_id' || hiddenFields.includes(key)) return;
+                    if (key === 'linked_to_id' && !IS_ADMIN) return;
                     const val = pd[key] == null ? '' : pd[key];
                     container.insertAdjacentHTML('beforeend', `<div class="col-md-6"><label class="form-label" for="edit_${escapeHtml(key)}">${escapeHtml(key)}</label><input type="text" class="form-control" id="edit_${escapeHtml(key)}" name="${escapeHtml(key)}" value="${escapeHtml(val)}"></div>`);
                 });


### PR DESCRIPTION
## Summary
- Avoid rendering the `linked_to_id` field in the edit user modal unless the logged-in user is an admin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e32a242c08332bab5d356eef73adb