### PR TITLE
feat: dynamic profit color and icon

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -399,15 +399,15 @@ Mon compte </button>
 </div>
 </div>
 <div class="col-md-6 col-lg-3">
-<div class="dashboard-stat stat-danger">
-<div class="d-flex justify-content-between align-items-center">
-<div>
-<h3 class="mb-0" id="profit">--- $</h3>
-<p class="mb-0">Profit</p>
-</div>
-<i class="fas fa-arrow-circle-up stat-icon"></i>
-</div>
-</div>
+  <div class="dashboard-stat stat-danger" id="profit-box">
+    <div class="d-flex justify-content-between align-items-center">
+      <div>
+        <h3 class="mb-0" id="profit">--- $</h3>
+        <p class="mb-0">Profit</p>
+      </div>
+      <i class="fas fa-chart-line stat-icon"></i>
+    </div>
+  </div>
 </div>
 <div class="col-md-6 col-lg-3">
 <div class="dashboard-stat stat-warning">

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -498,6 +498,11 @@ function initializeUI() {
         $('#totalDepots').text(formatDollar(dashboardData.personalData.totalDepots));
         const profit = dashboardData.personalData.balance - dashboardData.personalData.totalDepots;
         $('#profit').text(formatDollar(profit));
+
+        const $profitBox = $('#profit-box');
+        $profitBox.removeClass('stat-success stat-danger')
+            .addClass(profit >= 0 ? 'stat-success' : 'stat-danger');
+
         $('#nbTransactions').text(dashboardData.personalData.nbTransactions);
     }
 


### PR DESCRIPTION
## Summary
- update profit dashboard box to show chart icon
- add dynamic profit color based on positive or negative balance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e36b25dec83328c9536c4b4a8f553