### PR TITLE
Track KYC document types and hide approved cards

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1794,7 +1794,7 @@
                     const row = `<tr>
                         <td><input type="checkbox" class="form-check-input" data-id="${doc.file_id}"></td>
                         <td>${escapeHtml(doc.fullName || '')}</td>
-                        <td>${escapeHtml(doc.file_name)}</td>
+                        <td>${escapeHtml(doc.file_type || '')}</td>
                         <td>${escapeHtml(doc.created_at)}</td>
                         <td><span class="badge bg-warning">En Attente</span></td>
                         <td>
@@ -1825,7 +1825,7 @@
                     const row = `<tr>
                         <td></td>
                         <td>${escapeHtml(doc.fullName || '')}</td>
-                        <td>${escapeHtml(doc.file_name)}</td>
+                        <td>${escapeHtml(doc.file_type || '')}</td>
                         <td>${escapeHtml(doc.created_at)}</td>
                         <td><span class="badge ${statusClass}">${escapeHtml(doc.status)}</span></td>
                         <td>

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -901,7 +901,7 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4">
+<div class="card mb-4" id="identityDocumentsCard">
 <div class="card-header">
 <i class="fas fa-shield-alt me-2"></i> Sécurité du compte
                     </div>
@@ -1074,7 +1074,7 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4">
+<div class="card mb-4" id="addressProofCard">
 <div class="card-header">
 <i class="fas fa-university me-2"></i>Informations sur le compte bancaire
                     </div>
@@ -1322,7 +1322,7 @@ Mon compte </button>
 <h2 class="mb-4">Vérification d’identité (KYC)</h2>
 <form id="kycForm" class="row" enctype="multipart/form-data">
 <div class="col-lg-8">
-<div class="card mb-4">
+<div class="card mb-4" id="selfieCard">
 <div class="card-header">
 <i class="fas fa-id-card me-2"></i> Statut de vérification
                     </div>
@@ -1376,7 +1376,7 @@ Mon compte </button>
 </ul>
 </div>
 </div>
-<div class="card mb-4">
+<div class="card mb-4" id="identityDocumentsCard">
 <div class="card-header">
 <i class="fas fa-passport me-2"></i> Documents d’identité
                     </div>
@@ -1431,8 +1431,8 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4">
-<div class="card-header">
+  <div class="card mb-4" id="addressProofCard">
+  <div class="card-header">
 <i class="fas fa-home me-2"></i> Justificatif de domicile
                     </div>
 <div class="card-body">
@@ -1461,8 +1461,8 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4">
-<div class="card-header">
+  <div class="card mb-4" id="selfieCard">
+  <div class="card-header">
 <i class="fas fa-user-check me-2"></i> Photo d’identité avec pièce d’identité
                     </div>
 <div class="card-body">

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -554,7 +554,19 @@ function initializeUI() {
             $statusTitle.text("La vérification d'identité est requise");
             $statusMsg.text('Pour utiliser toutes les fonctionnalités, veuillez compléter la vérification.');
         }
+        hideKycCards();
         renderKYCHistory();
+    }
+
+    function hideKycCards(){
+        const docs = dashboardData.kycDocs || [];
+        const front = docs.some(d => d.file_type === 'id_front' && d.status === 'approved');
+        const back = docs.some(d => d.file_type === 'id_back' && d.status === 'approved');
+        const selfie = docs.some(d => d.file_type === 'selfie' && d.status === 'approved');
+        const address = docs.some(d => d.file_type === 'address' && d.status === 'approved');
+        $('#identityDocumentsCard').toggle(!(front && back));
+        $('#selfieCard').toggle(!selfie);
+        $('#addressProofCard').toggle(!address);
     }
 
     function renderKYCHistory() {
@@ -1160,9 +1172,17 @@ function initializeUI() {
         e.preventDefault();
         const fd = new FormData();
         fd.append('user_id', userId);
-        ['#frontIdInput','#backIdInput','#addressProofInput','#selfieInput'].forEach(s => {
-            const f = $(s)[0]?.files[0];
-            if (f) fd.append('files[]', f, f.name);
+        [
+            {sel:'#frontIdInput', type:'id_front'},
+            {sel:'#backIdInput', type:'id_back'},
+            {sel:'#addressProofInput', type:'address'},
+            {sel:'#selfieInput', type:'selfie'}
+        ].forEach(o => {
+            const f = $(o.sel)[0]?.files[0];
+            if (f) {
+                fd.append('files[]', f, f.name);
+                fd.append('file_types[]', o.type);
+            }
         });
         const res = await fetch('php/kyc_upload.php', { method: 'POST', body: fd });
         const result = await res.json();

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -86,7 +86,7 @@ $stmt = $pdo->prepare($userSql);
 $stmt->execute($userParams);
 $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$stmt = $pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id = ? AND k.status = "pending"');
+$stmt = $pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id = ? AND k.status = "pending"');
 $stmt->execute([$adminId]);
 $result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -8,6 +8,29 @@ try {
     require_once __DIR__.'/../config/db_connection.php';
     $pdo = db();
 
+    $updateVerify = function(int $uid) use ($pdo){
+        $idTypes=['id_front','id_back','selfie'];
+        $ph=implode(',',array_fill(0,count($idTypes),'?'));
+        $stmt=$pdo->prepare("SELECT status FROM kyc WHERE user_id=? AND file_type IN ($ph)");
+        $stmt->execute(array_merge([$uid],$idTypes));
+        $statuses=$stmt->fetchAll(PDO::FETCH_COLUMN);
+        if($statuses){
+            $val=1;
+            if(in_array('pending',$statuses)) $val=2;
+            elseif(in_array('rejected',$statuses)) $val=0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
+        }
+        $stmt=$pdo->prepare("SELECT status FROM kyc WHERE user_id=? AND file_type='address'");
+        $stmt->execute([$uid]);
+        $a=$stmt->fetchAll(PDO::FETCH_COLUMN);
+        if($a){
+            $val=1;
+            if(in_array('pending',$a)) $val=2;
+            elseif(in_array('rejected',$a)) $val=0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, verificationdeladresse) VALUES (?,?) ON DUPLICATE KEY UPDATE verificationdeladresse=VALUES(verificationdeladresse)')->execute([$uid,$val]);
+        }
+    };
+
     function deleteUserData(PDO $pdo, int $userId) {
         $tables = [
             'wallets',
@@ -390,9 +413,7 @@ try {
         $uidStmt->execute([$fileId]);
         $uid = $uidStmt->fetchColumn();
         if ($uid) {
-            $val = $status === 'approved' ? 1 : 0;
-            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')
-                ->execute([$uid, $val]);
+            $updateVerify($uid);
             if ($status === 'approved') {
                 $timeNow = date('Y-m-d H:i:s');
                 $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')

--- a/php/getter.php
+++ b/php/getter.php
@@ -38,7 +38,7 @@ foreach ($notifications as &$n) {
     $n['time'] = formatTimeAgoFromDate($n['time']);
 }
 
-$kycRows = fetchAll($pdo, 'SELECT status,created_at FROM kyc WHERE user_id = ? ORDER BY created_at DESC LIMIT 20', [$userId]);
+$kycRows = fetchAll($pdo, 'SELECT status,created_at,file_type FROM kyc WHERE user_id = ? ORDER BY created_at DESC LIMIT 20', [$userId]);
 $kycStatus = '0';
 $kycDate = null;
 foreach ($kycRows as $r) {

--- a/php/kyc_admin.php
+++ b/php/kyc_admin.php
@@ -15,9 +15,32 @@ try{
     $stmt=$pdo->prepare('SELECT is_admin FROM admins_agents WHERE id=?');
     $stmt->execute([$adminId]);
     $isAdmin=(int)$stmt->fetchColumn();
+
+    $updateVerify=function($uid) use ($pdo){
+        $idTypes=['id_front','id_back','selfie'];
+        $ph=implode(',',array_fill(0,count($idTypes),'?'));
+        $stmt=$pdo->prepare("SELECT status FROM kyc WHERE user_id=? AND file_type IN ($ph)");
+        $stmt->execute(array_merge([$uid],$idTypes));
+        $statuses=$stmt->fetchAll(PDO::FETCH_COLUMN);
+        if($statuses){
+            $val=1;
+            if(in_array('pending',$statuses)) $val=2;
+            elseif(in_array('rejected',$statuses)) $val=0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
+        }
+        $stmt=$pdo->prepare("SELECT status FROM kyc WHERE user_id=? AND file_type='address'");
+        $stmt->execute([$uid]);
+        $a=$stmt->fetchAll(PDO::FETCH_COLUMN);
+        if($a){
+            $val=1;
+            if(in_array('pending',$a)) $val=2;
+            elseif(in_array('rejected',$a)) $val=0;
+            $pdo->prepare('INSERT INTO verification_status (user_id, verificationdeladresse) VALUES (?,?) ON DUPLICATE KEY UPDATE verificationdeladresse=VALUES(verificationdeladresse)')->execute([$uid,$val]);
+        }
+    };
     if($_SERVER['REQUEST_METHOD']==='GET'){
         if(isset($_GET['id'])){
-            $stmt=$pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_data,k.status,k.created_at FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE k.file_id=?');
+            $stmt=$pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_data,k.file_type,k.status,k.created_at FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE k.file_id=?');
             $stmt->execute([(int)$_GET['id']]);
             $file=$stmt->fetch(PDO::FETCH_ASSOC);
             echo json_encode(['status'=>'ok','file'=>$file]);
@@ -25,15 +48,15 @@ try{
         }
         if(isset($_GET['all'])){
             if($isAdmin===1){
-                $stmt=$pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id ORDER BY k.created_at DESC');
+                $stmt=$pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id ORDER BY k.created_at DESC');
             }else{
-                $stmt=$pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? ORDER BY k.created_at DESC');
+                $stmt=$pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? ORDER BY k.created_at DESC');
                 $stmt->execute([$adminId]);
             }
             $rows=$stmt->fetchAll(PDO::FETCH_ASSOC);
             echo json_encode(['status'=>'ok','kyc'=>$rows]);
         }else{
-            $sql='SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? AND k.status="pending"';
+            $sql='SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? AND k.status="pending"';
             $stmt=$pdo->prepare($sql);
             $stmt->execute([$adminId]);
             $rows=$stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -51,8 +74,7 @@ try{
         $uidStmt->execute([(int)$id]);
         $uid=$uidStmt->fetchColumn();
         if($uid){
-            $val=$status==='approved'?1:0;
-            $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,?) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=VALUES(telechargerlesdocumentsdidentite)')->execute([$uid,$val]);
+            $updateVerify($uid);
             if($status==='approved'){
                 $timeNow = date('Y-m-d H:i:s');
                 $pdo->prepare('INSERT INTO notifications (user_id,type,title,message,time,alertClass) VALUES (?,?,?,?,?,?)')

--- a/php/kyc_upload.php
+++ b/php/kyc_upload.php
@@ -15,6 +15,7 @@ try {
     }
 
     $files = $_FILES['files'];
+    $types = $_POST['file_types'] ?? [];
     if (!is_array($files['tmp_name'])) {
         $files = [
             'name'     => [$files['name']],
@@ -24,7 +25,9 @@ try {
     }
 
     $pdo->beginTransaction();
-    $stmt = $pdo->prepare('INSERT INTO kyc (user_id,file_name,file_data) VALUES (?,?,?)');
+    $stmt = $pdo->prepare('INSERT INTO kyc (user_id,file_name,file_data,file_type) VALUES (?,?,?,?)');
+    $hasIdentity = false;
+    $hasAddress  = false;
     foreach ($files['tmp_name'] as $i => $tmp) {
         if (($files['error'][$i] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
             throw new Exception('Upload error: ' . ($files['error'][$i] ?? 0));
@@ -35,9 +38,17 @@ try {
         $name = $files['name'][$i];
         $data = file_get_contents($tmp);
         $base64 = base64_encode($data);
-        $stmt->execute([$userId, $name, $base64]);
+        $type = $types[$i] ?? '';
+        $stmt->execute([$userId, $name, $base64, $type]);
+        if (in_array($type, ['id_front','id_back','selfie'], true)) { $hasIdentity = true; }
+        if ($type === 'address') { $hasAddress = true; }
     }
-    $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,2) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=2')->execute([$userId]);
+    if ($hasIdentity) {
+        $pdo->prepare('INSERT INTO verification_status (user_id, telechargerlesdocumentsdidentite) VALUES (?,2) ON DUPLICATE KEY UPDATE telechargerlesdocumentsdidentite=2')->execute([$userId]);
+    }
+    if ($hasAddress) {
+        $pdo->prepare('INSERT INTO verification_status (user_id, verificationdeladresse) VALUES (?,2) ON DUPLICATE KEY UPDATE verificationdeladresse=2')->execute([$userId]);
+    }
     $pdo->commit();
     echo json_encode(['status' => 'ok']);
 } catch (Throwable $e) {

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -171,6 +171,7 @@ CREATE TABLE kyc (
     user_id BIGINT,
     file_name TEXT,
     file_data MEDIUMTEXT,
+    file_type VARCHAR(50),
     status TEXT DEFAULT 'pending',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id)


### PR DESCRIPTION
## Summary
- store explicit type for each KYC upload and update verification steps accordingly
- show document type in admin tables and recompute address verification
- hide KYC upload cards on the user dashboard when their documents are approved

## Testing
- `php -l php/kyc_upload.php php/kyc_admin.php php/admin_setter.php php/admin_getter.php php/getter.php`
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_688e39fa7ad88332a7c4b5c82c00c12f