### PR TITLE
fix: hide KYC cards after approval

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1322,7 +1322,7 @@ Mon compte </button>
 <h2 class="mb-4">Vérification d’identité (KYC)</h2>
 <form id="kycForm" class="row" enctype="multipart/form-data">
 <div class="col-lg-8">
-<div class="card mb-4" id="selfieCard">
+<div class="card mb-4">
 <div class="card-header">
 <i class="fas fa-id-card me-2"></i> Statut de vérification
                     </div>


### PR DESCRIPTION
## Summary
- remove duplicate `selfieCard` id in KYC status card so the correct sections are toggled

## Testing
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_688e3e525e688332987152c20bfffa44