### PR TITLE
Fix KYC card visibility by removing duplicate IDs

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -901,7 +901,7 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4" id="identityDocumentsCard">
+<div class="card mb-4" id="accountSecurityCard">
 <div class="card-header">
 <i class="fas fa-shield-alt me-2"></i> Sécurité du compte
                     </div>
@@ -1074,7 +1074,7 @@ Mon compte </button>
 </div>
 </div>
 </div>
-<div class="card mb-4" id="addressProofCard">
+<div class="card mb-4" id="bankAccountCard">
 <div class="card-header">
 <i class="fas fa-university me-2"></i>Informations sur le compte bancaire
                     </div>


### PR DESCRIPTION
## Summary
- Rename duplicate `identityDocumentsCard` and `addressProofCard` elements so KYC sections hide correctly after admin approval

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e414bebc483328c82a75e46b2904a