### PR TITLE
Toggle KYC submit button when documents approved

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1481,7 +1481,7 @@ Mon compte </button>
 </div>
 </div>
 <div class="d-grid gap-2">
-<button class="btn btn-primary btn-lg" type="submit">
+<button class="btn btn-primary btn-lg" type="submit" id="kycSubmitButton">
 <i class="fas fa-paper-plane me-2"></i>Envoyer pour vérification </button>
 </div>
 </div>

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -564,9 +564,11 @@ function initializeUI() {
         const back = docs.some(d => d.file_type === 'id_back' && d.status === 'approved');
         const selfie = docs.some(d => d.file_type === 'selfie' && d.status === 'approved');
         const address = docs.some(d => d.file_type === 'address' && d.status === 'approved');
+        const allApproved = front && back && selfie && address;
         $('#identityDocumentsCard').toggle(!(front && back));
         $('#selfieCard').toggle(!selfie);
         $('#addressProofCard').toggle(!address);
+        $('#kycSubmitButton').toggle(!allApproved);
     }
 
     function renderKYCHistory() {


### PR DESCRIPTION
## Summary
- Hide KYC upload cards and submit button based on document approval
- Add `kycSubmitButton` ID for KYC submission control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e44778da88332a69da40c08debdb2