### PR TITLE
fix: skip validation for hidden KYC fields

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1414,7 +1414,7 @@ Mon compte </button>
 </div>
 <div class="mb-3">
 <label class="form-label" for="idType">Type Identité</label>
-<select class="form-select" id="idType" required="">
+<select class="form-select" id="idType" name="idType" required="">
 <option value="">-- Choisissez le type d’identité --</option>
 <option value="national_id">Carte d’identité nationale</option>
 <option value="passport">Passeport</option>
@@ -1447,7 +1447,7 @@ Mon compte </button>
 </div>
 <div class="mb-3">
 <label class="form-label" for="documentType">Type de document</label>
-<select class="form-select" id="documentType" required="">
+<select class="form-select" id="documentType" name="documentType" required="">
 <option value="">-- Choisissez le type de document --</option>
 <option value="utility_bill">Facture de services publics (électricité, eau, gaz)</option>
 <option value="bank_statement">Relevé de compte bancaire</option>

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -565,10 +565,30 @@ function initializeUI() {
         const selfie = docs.some(d => d.file_type === 'selfie' && d.status === 'approved');
         const address = docs.some(d => d.file_type === 'address' && d.status === 'approved');
         const allApproved = front && back && selfie && address;
-        $('#identityDocumentsCard').toggle(!(front && back));
-        $('#selfieCard').toggle(!selfie);
-        $('#addressProofCard').toggle(!address);
+
+        const $identityCard = $('#identityDocumentsCard');
+        const $selfieCard = $('#selfieCard');
+        const $addressCard = $('#addressProofCard');
+
+        const showIdentity = !(front && back);
+        const showSelfie = !selfie;
+        const showAddress = !address;
+
+        $identityCard.toggle(showIdentity);
+        $selfieCard.toggle(showSelfie);
+        $addressCard.toggle(showAddress);
         $('#kycSubmitButton').toggle(!allApproved);
+
+        setCardRequired($identityCard, showIdentity);
+        setCardRequired($selfieCard, showSelfie);
+        setCardRequired($addressCard, showAddress);
+    }
+
+    function setCardRequired($card, enable){
+        $card.find('input, select').each(function(){
+            $(this).prop('required', enable);
+            $(this).prop('disabled', !enable);
+        });
     }
 
     function renderKYCHistory() {


### PR DESCRIPTION
## Summary
- stop KYC form validation for hidden sections by disabling their inputs
- add missing name attributes on KYC document select fields

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e469d8d688332b346cc7cbce62458