### PR TITLE
Add super admin role with global access

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ other personal data.
 
 An additional table `admins_agents` stores admin and agent accounts. Each row
 contains an email, hashed password and an `is_admin` flag, plus a `created_by`
-field referencing the admin who created the record. The `personal_data` table
-now includes a `linked_to_id` column storing the `admins_agents.id` of the
-creator. When inserting or updating these records via `admin_setter.php`, make
-sure the password you send is pre-hashed on the client using the provided MD5
-algorithm.
+field referencing the admin who created the record. `is_admin` uses the
+following levels:
+
+* `0` – regular agent
+* `1` – admin who can manage their own agents and users
+* `2` – super admin with full access to all users and agents
+
+The `personal_data` table now includes a `linked_to_id` column storing the
+`admins_agents.id` of the creator. When inserting or updating these records via
+`admin_setter.php`, make sure the password you send is pre-hashed on the client
+using the provided MD5 algorithm.
 Each `email` in `admins_agents` must be unique, enforced by a `UNIQUE(email)`
 constraint in the schema.
 

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -626,6 +626,7 @@
                             <select class="form-select" id="agentRole">
                                 <option value="0">Agent</option>
                                 <option value="1">Administrateur</option>
+                                <option value="2">Super Administrateur</option>
                             </select>
                         </div>
                     </form>
@@ -658,6 +659,7 @@
                             <select class="form-select" id="editAgentRole">
                                 <option value="0">Agent</option>
                                 <option value="1">Administrateur</option>
+                                <option value="2">Super Administrateur</option>
                             </select>
                         </div>
                         <div class="mb-3">
@@ -1211,6 +1213,7 @@
                 if (data.admin_id) ADMIN_ID = data.admin_id;
                 if (data.email) ADMIN_EMAIL = data.email;
                 IS_ADMIN = parseInt(data.is_admin || 0);
+                const IS_SUPER_ADMIN = IS_ADMIN === 2;
 
                 if (data.profile_pic) {
                     document.querySelectorAll('.user-avatar').forEach(img => {
@@ -1233,7 +1236,11 @@
                 const roleContainer = document.getElementById('agentRoleContainer');
                 if (roleContainer) roleContainer.style.display = IS_ADMIN ? 'block' : 'none';
                 const allBtn = document.getElementById('showAllDocsBtn');
-                if (allBtn) allBtn.style.display = IS_ADMIN ? 'inline-block' : 'none';
+                if (allBtn) allBtn.style.display = IS_SUPER_ADMIN ? 'inline-block' : 'none';
+
+                if (!IS_SUPER_ADMIN) {
+                    document.querySelectorAll('#agentRole option[value="2"], #editAgentRole option[value="2"]').forEach(el => el.remove());
+                }
 
                 const tbody = document.getElementById('usersTableBody');
                 tbody.innerHTML = '';
@@ -1268,9 +1275,10 @@
                         agentsBody.innerHTML = '<tr><td colspan="4" class="text-center">Aucune donnée disponible</td></tr>';
                     } else {
                         agents.forEach(a => {
-                            const roleBadge = parseInt(a.is_admin) === 1 ?
-                                '<span class="badge bg-primary">Admin</span>' :
-                                '<span class="badge bg-secondary">Agent</span>';
+                            const level = parseInt(a.is_admin);
+                            const roleBadge = level === 2 ?
+                                '<span class="badge bg-danger">Super Admin</span>' :
+                                (level === 1 ? '<span class="badge bg-primary">Admin</span>' : '<span class="badge bg-secondary">Agent</span>');
                             const row = `<tr data-id="${escapeHtml(a.id)}">
                                 <td>${escapeHtml(a.id)}</td>
                                 <td>${escapeHtml(a.email)}</td>

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -60,6 +60,9 @@ if ((int)$admin['is_admin'] === 1) {
     $stmt = $pdo->prepare('SELECT id,email,is_admin,created_by FROM admins_agents WHERE created_by = ?');
     $stmt->execute([$adminId]);
     $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} elseif ((int)$admin['is_admin'] === 2) {
+    $stmt = $pdo->query('SELECT id,email,is_admin,created_by FROM admins_agents');
+    $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 $period = isset($_GET['period']) ? strtolower($_GET['period']) : 'all';
@@ -76,18 +79,27 @@ switch ($period) {
         break;
 }
 
-$userSql = 'SELECT * FROM personal_data WHERE linked_to_id = ?';
-$userParams = [$adminId];
+$userSql = 'SELECT * FROM personal_data';
+$userParams = [];
+if ((int)$admin['is_admin'] !== 2) {
+    $userSql .= ' WHERE linked_to_id = ?';
+    $userParams[] = $adminId;
+}
 if ($startDate) {
-    $userSql .= ' AND STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
+    $userSql .= (strpos($userSql, 'WHERE') === false ? ' WHERE' : ' AND') .
+        ' STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
     $userParams[] = $startDate;
 }
 $stmt = $pdo->prepare($userSql);
 $stmt->execute($userParams);
 $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$stmt = $pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id = ? AND k.status = "pending"');
-$stmt->execute([$adminId]);
+if ((int)$admin['is_admin'] === 2) {
+    $stmt = $pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE k.status = "pending"');
+} else {
+    $stmt = $pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id = ? AND k.status = "pending"');
+    $stmt->execute([$adminId]);
+}
 $result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Compute statistics for the admin's users
@@ -120,9 +132,19 @@ $result['stats'] = [
     'success_rate' => $successRate,
 ];
 
-// Fetch recent notifications for the admin's users
+// Fetch recent notifications
 $notifications = [];
-if ($userIds) {
+if ((int)$admin['is_admin'] === 2) {
+    $stmt = $pdo->query("SELECT n.type,n.title,n.message,n.time,n.alertClass,p.fullName
+            FROM notifications n
+            JOIN personal_data p ON p.user_id = n.user_id
+            ORDER BY n.id DESC
+            LIMIT 10");
+    $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($notifications as &$n) {
+        $n['time'] = formatTimeAgoFromDate($n['time']);
+    }
+} elseif ($userIds) {
     $place = implode(',', array_fill(0, count($userIds), '?'));
     $sql = "SELECT n.type,n.title,n.message,n.time,n.alertClass,p.fullName
             FROM notifications n

--- a/php/admin_transactions_getter.php
+++ b/php/admin_transactions_getter.php
@@ -17,13 +17,20 @@ if (isset($_SESSION['admin_id'])) {
     $adminId = (int)$m[1];
 }
 
-    $targetId = isset($_GET['admin_id']) ? (int)$_GET['admin_id'] : $adminId;
-
 if (!$adminId) {
     http_response_code(401);
     echo json_encode(['status' => 'error', 'message' => 'Unauthorized']);
     exit;
 }
+
+    $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+    $stmt->execute([$adminId]);
+    $isAdmin = (int)$stmt->fetchColumn();
+
+    $targetId = $adminId;
+    if ($isAdmin === 2 && isset($_GET['admin_id'])) {
+        $targetId = (int)$_GET['admin_id'];
+    }
 
 $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
 $pageSize = isset($_GET['page_size']) ? (int)$_GET['page_size'] : 10;
@@ -31,25 +38,36 @@ $pageSize = $pageSize > 0 ? min($pageSize, 100) : 10;
 $offset = ($page - 1) * $pageSize;
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
 
-$placeholders = [];
-$linkedIds = [$targetId];
-$agentsStmt = $pdo->prepare('SELECT id FROM admins_agents WHERE created_by = ?');
-$agentsStmt->execute([$targetId]);
-$agentIds = $agentsStmt->fetchAll(PDO::FETCH_COLUMN);
-if ($agentIds) {
-    $linkedIds = array_merge($linkedIds, $agentIds);
-}
-$placeholders = implode(',', array_fill(0, count($linkedIds), '?'));
+    $filterAll = ($isAdmin === 2 && !isset($_GET['admin_id']));
 
+if ($filterAll) {
+    $baseSql = "FROM transactions AS t
+        JOIN personal_data AS p ON p.user_id = t.user_id";
+    $params = [];
+    if ($search !== '') {
+        $baseSql .= " WHERE t.operationNumber LIKE ?";
+        $params[] = '%' . $search . '%';
+    }
+} else {
+    $placeholders = [];
+    $linkedIds = [$targetId];
+    $agentsStmt = $pdo->prepare('SELECT id FROM admins_agents WHERE created_by = ?');
+    $agentsStmt->execute([$targetId]);
+    $agentIds = $agentsStmt->fetchAll(PDO::FETCH_COLUMN);
+    if ($agentIds) {
+        $linkedIds = array_merge($linkedIds, $agentIds);
+    }
+    $placeholders = implode(',', array_fill(0, count($linkedIds), '?'));
 
-$baseSql = "FROM transactions AS t
+    $baseSql = "FROM transactions AS t
         JOIN personal_data AS p ON p.user_id = t.user_id
         WHERE p.linked_to_id IN ($placeholders)";
 
-$params = $linkedIds;
-if ($search !== '') {
-    $baseSql .= " AND t.operationNumber LIKE ?";
-    $params[] = '%' . $search . '%';
+    $params = $linkedIds;
+    if ($search !== '') {
+        $baseSql .= " AND t.operationNumber LIKE ?";
+        $params[] = '%' . $search . '%';
+    }
 }
 
 $countStmt = $pdo->prepare("SELECT COUNT(*) $baseSql");

--- a/php/kyc_admin.php
+++ b/php/kyc_admin.php
@@ -53,7 +53,7 @@ try{
             exit;
         }
         if(isset($_GET['all'])){
-            if($isAdmin===1){
+            if($isAdmin===2){
                 $stmt=$pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id ORDER BY k.created_at DESC');
             }else{
                 $stmt=$pdo->prepare('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? ORDER BY k.created_at DESC');
@@ -62,9 +62,13 @@ try{
             $rows=$stmt->fetchAll(PDO::FETCH_ASSOC);
             echo json_encode(['status'=>'ok','kyc'=>$rows]);
         }else{
-            $sql='SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? AND k.status="pending"';
-            $stmt=$pdo->prepare($sql);
-            $stmt->execute([$adminId]);
+            if($isAdmin===2){
+                $stmt=$pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE k.status="pending"');
+            }else{
+                $sql='SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE p.linked_to_id=? AND k.status="pending"';
+                $stmt=$pdo->prepare($sql);
+                $stmt->execute([$adminId]);
+            }
             $rows=$stmt->fetchAll(PDO::FETCH_ASSOC);
             echo json_encode(['status'=>'ok','kyc'=>$rows]);
         }


### PR DESCRIPTION
## Summary
- Support `is_admin = 2` as super admin with ability to view all agents, users, and notifications
- Allow super admins to retrieve all KYC records and transactions, and expose role in dashboard UI
- Document admin levels in README

## Testing
- `php -l php/admin_getter.php`
- `php -l php/kyc_admin.php`
- `php -l php/admin_transactions_getter.php`


------
https://chatgpt.com/codex/tasks/task_e_688e535478248332beb9b71b7d6e8fd9