### PR TITLE
feat: allow editing trading profits

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -856,6 +856,35 @@
         </div>
     </div>
 
+    <!-- Edit Transaction Modal -->
+    <div class="modal fade" id="editTransactionModal" tabindex="-1">
+        <div class="modal-dialog">
+            <form id="editTransactionForm" class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Modifier la transaction</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="editTxId">
+                    <input type="hidden" id="editTxOldProfit">
+                    <input type="hidden" id="editTxOldPrice">
+                    <div class="mb-3">
+                        <label for="editTxProfit" class="form-label">Profit/Perte</label>
+                        <input type="number" step="0.01" class="form-control" id="editTxProfit" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="editTxPrice" class="form-label">Le prix</label>
+                        <input type="number" step="0.01" class="form-control" id="editTxPrice" readonly>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-primary">Enregistrer</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
@@ -1743,13 +1772,14 @@
                     const acceptBtn = hideAccept ? ''
                         : `<button class="btn btn-sm btn-outline-success tx-accept" title="Complete"><i class="fas fa-check"></i></button>`;
                     const row = `<tr data-id="${escapeHtml(t.operationNumber)}">`
-                        + `<td class="text-muted fw-bold">${escapeHtml(t.operationNumber)}</td>`
+                    + `<td class="text-muted fw-bold">${escapeHtml(t.operationNumber)}</td>`
                     + `<td>${escapeHtml(t.user_id)}</td>`
                     + `<td><span class="badge ${escapeHtml(typeClasses[t.type] || 'bg-secondary')}">${escapeHtml(t.type || '')}</span></td>`
                     + `<td>${formatDollar(t.amount || 0)}</td>`
                     + `<td><span class="badge ${escapeHtml(t.statusClass || 'bg-secondary')}">${escapeHtml(t.status || '')}</span></td>`
                     + `<td>${escapeHtml(t.date || '')}</td>`
                     + `<td class="text-nowrap">`
+                    + `<button class="btn btn-sm btn-outline-primary me-1 tx-edit" title="Edit"><i class="fas fa-edit"></i></button>`
                     + `<button class="btn btn-sm btn-outline-danger me-1 tx-reject" title="Reject"><i class="fas fa-times"></i></button>`
                     + `<button class="btn btn-sm btn-outline-secondary me-1 tx-remove" title="Remove"><i class="fas fa-trash-alt"></i></button>`
                     + acceptBtn
@@ -1866,12 +1896,35 @@
             loadTransactions();
         }
 
+        async function openEditTransaction(id) {
+            try {
+                const res = await fetchWithAuth('php/admin_trade_getter.php?op=' + encodeURIComponent(id));
+                const data = await res.json();
+                const trade = data.trade || {};
+                document.getElementById('editTxId').value = id;
+                document.getElementById('editTxProfit').value = trade.profitPerte ?? '';
+                document.getElementById('editTxPrice').value = trade.prix ?? '';
+                document.getElementById('editTxOldProfit').value = trade.profitPerte ?? '';
+                document.getElementById('editTxOldPrice').value = trade.prix ?? '';
+                new bootstrap.Modal(document.getElementById('editTransactionModal')).show();
+            } catch (err) {
+                console.error('Failed to load trade', err);
+            }
+        }
+
         const txBody = document.getElementById('transactionsTableBody');
         if (txBody) {
             txBody.addEventListener('click', function(e) {
                 const id = e.target.closest('tr')?.getAttribute('data-id');
                 if (!id) return;
-                if (e.target.closest('.tx-accept')) {
+                if (e.target.closest('.tx-edit')) {
+                    const tx = ALL_TXS.find(t => t.operationNumber === id);
+                    if (tx && tx.type === 'Trading') {
+                        openEditTransaction(id);
+                    } else {
+                        alert('Cette transaction ne peut pas être modifiée.');
+                    }
+                } else if (e.target.closest('.tx-accept')) {
                     updateTransaction(id, 'complet', 'bg-success');
                 } else if (e.target.closest('.tx-reject')) {
                     updateTransaction(id, 'reject', 'bg-danger');
@@ -1899,6 +1952,33 @@
             if (!isNaN(page)) {
                 TX_PAGE = page;
                 loadTransactions();
+            }
+        });
+
+        const profitInput = document.getElementById('editTxProfit');
+        if (profitInput) profitInput.addEventListener('input', function() {
+            const oldProfit = parseFloat(document.getElementById('editTxOldProfit').value) || 0;
+            const oldPrice = parseFloat(document.getElementById('editTxOldPrice').value) || 0;
+            const newProfit = parseFloat(this.value) || 0;
+            const newPrice = oldPrice + (newProfit - oldProfit);
+            document.getElementById('editTxPrice').value = newPrice.toFixed(2);
+        });
+
+        const editTxForm = document.getElementById('editTransactionForm');
+        if (editTxForm) editTxForm.addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const op = document.getElementById('editTxId').value;
+            const profit = parseFloat(document.getElementById('editTxProfit').value) || 0;
+            try {
+                await fetchWithAuth('php/admin_setter.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'edit_trade_profit', operationNumber: op, profit: profit })
+                });
+                bootstrap.Modal.getInstance(document.getElementById('editTransactionModal')).hide();
+                loadTransactions();
+            } catch (err) {
+                console.error('Failed to update trade', err);
             }
         });
 

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -255,6 +255,31 @@ try {
             $pdo->rollBack();
             throw $e;
         }
+    } elseif ($action === 'edit_trade_profit') {
+        $op = isset($data['operationNumber']) ? trim($data['operationNumber']) : '';
+        $profit = isset($data['profit']) ? (float)$data['profit'] : null;
+        if ($op === '' || $profit === null) {
+            throw new Exception('Missing parameters');
+        }
+        $pdo->beginTransaction();
+        try {
+            $stmt = $pdo->prepare('SELECT prix, profitPerte FROM tradingHistory WHERE operationNumber = ? FOR UPDATE');
+            $stmt->execute([$op]);
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$row) {
+                throw new Exception('Trade not found');
+            }
+            $oldPrice = (float)$row['prix'];
+            $oldProfit = (float)$row['profitPerte'];
+            $newPrice = $oldPrice + ($profit - $oldProfit);
+            $upd = $pdo->prepare('UPDATE tradingHistory SET profitPerte = ?, prix = ? WHERE operationNumber = ?');
+            $upd->execute([$profit, $newPrice, $op]);
+            $pdo->commit();
+            echo json_encode(['status' => 'ok', 'prix' => $newPrice]);
+        } catch (Exception $e) {
+            $pdo->rollBack();
+            throw $e;
+        }
     } elseif ($action === 'update_transaction') {
         $op = isset($data['id']) ? trim($data['id']) : '';
         if ($op === '') {

--- a/php/admin_trade_getter.php
+++ b/php/admin_trade_getter.php
@@ -1,0 +1,41 @@
+<?php
+header('Content-Type: application/json');
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+});
+
+try {
+    require_once __DIR__ . '/../config/db_connection.php';
+    $pdo = db();
+
+    session_start();
+    $adminId = null;
+    if (isset($_SESSION['admin_id'])) {
+        $adminId = (int)$_SESSION['admin_id'];
+    } elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
+        preg_match('/Bearer\s+(\d+)/i', $_SERVER['HTTP_AUTHORIZATION'], $m)) {
+        $adminId = (int)$m[1];
+    }
+
+    if (!$adminId) {
+        http_response_code(401);
+        echo json_encode(['status' => 'error', 'message' => 'Unauthorized']);
+        exit;
+    }
+
+    $op = isset($_GET['op']) ? trim($_GET['op']) : '';
+    if ($op === '') {
+        throw new Exception('Missing op');
+    }
+
+    $stmt = $pdo->prepare('SELECT profitPerte, prix FROM tradingHistory WHERE operationNumber = ?');
+    $stmt->execute([$op]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    echo json_encode(['trade' => $row]);
+} catch (Throwable $e) {
+    error_log(__FILE__ . ' - ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add edit button and modal in admin dashboard for trading transactions
- recalculate price automatically when profit/loss is updated
- support editing trading profit via new admin endpoints

## Testing
- `php -l php/admin_trade_getter.php`
- `php -l php/admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_688e585ec788833293fc2a2599ea3835