### PR TITLE
Use default logo for admin avatar

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -164,10 +164,11 @@
                             <span class="me-3">Bienvenue, Administrateur</span>
                             <div class="dropdown">
                                 <button class="btn btn-outline-secondary dropdown-toggle d-flex align-items-center" type="button" data-bs-toggle="dropdown" id="adminAccountDropdown" aria-expanded="false">
+                                    <i class="bi bi-person-circle"></i>
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="adminAccountDropdown" style="min-width: 250px;">
                                     <li class="dropdown-header text-center">
-                                        <img alt="Image Utilisateur" class="rounded-circle mb-2 user-avatar" src="" style="width: 60px; height: 60px;"/>
+                                        <img alt="Image Utilisateur" class="rounded-circle mb-2 user-avatar" src="img/logo.png" style="width: 60px; height: 60px;"/>
                                         <div class="fw-bold">Administrateur</div>
                                     </li>
                                     <li><hr class="dropdown-divider"/></li>

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -118,7 +118,7 @@
 Mon compte </button>
 <ul aria-labelledby="accountDropdown" class="dropdown-menu dropdown-menu-end" style="min-width: 250px;">
 <li class="dropdown-header text-center">
-<img alt="Image Utilisateur" class="rounded-circle mb-2 user-avatar" src="" style="width: 60px; height: 60px;"/>
+<img alt="Image Utilisateur" class="rounded-circle mb-2 user-avatar" src="img/logo.png" style="width: 60px; height: 60px;"/>
 <div class="fw-bold" id="nameincompte">---</div>
 </li>
 <li>


### PR DESCRIPTION
## Summary
- add person icon to admin dropdown button
- default admin avatar uses `img/logo.png` on admin and user dashboards

## Testing
- `npx --yes htmlhint --rules "src-not-empty:false,tag-pair:false" dashboard_admin.html dashbord_user.html`

------
https://chatgpt.com/codex/tasks/task_e_688ed4a6cf9c8332a96383a87e983ecf