### PR TITLE
Adjust KYC progress bar completion color

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -80,6 +80,7 @@ function showBootstrapAlert(containerId, message, type = 'success') {
 }
 
 function progressToColor(percent) {
+    if (percent >= 100) return '#198754';
     const r = Math.round(255 * (100 - percent) / 100);
     const g = Math.round(255 * percent / 100);
     return `rgb(${r},${g},0)`;


### PR DESCRIPTION
## Summary
- use bootstrap's success green (#198754) when KYC progress reaches 100%

## Testing
- `node --check js/updatePrices.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ed85693888332a08eb29e8f1bb464