### PR TITLE
Add About section to landing page

### DIFF
--- a/enhanced_index.html
+++ b/enhanced_index.html
@@ -62,6 +62,10 @@
             background: #f8fafc;
         }
 
+        .light-mode .about-section {
+            background: #ffffff;
+        }
+
         .light-mode .features-section {
             background: #ffffff;
         }
@@ -363,6 +367,21 @@
 
         .light-mode .text-muted {
             color: #64748b !important;
+        }
+
+        /* About Section */
+        .about-section {
+            padding: 80px 0;
+            background: var(--dark-bg);
+        }
+
+        .about-section .about-text {
+            max-width: 800px;
+            margin: 0 auto;
+            color: var(--text-gray);
+            text-align: center;
+            font-size: 1.1rem;
+            line-height: 1.6;
         }
 
         /* Features Section */
@@ -914,6 +933,19 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </section>
+
+    <!-- About Section -->
+    <section id="about" class="about-section">
+        <div class="container text-center">
+            <h2 class="section-title">About Coin Trade</h2>
+            <p class="section-subtitle about-text">
+                Coin Trade is a professional cryptocurrency trading platform
+                designed for speed, security, and global accessibility. Our
+                mission is to empower traders of all levels with advanced tools
+                and real-time data.
+            </p>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Add About section to main landing page with platform overview
- Include styling and light-mode support for the new section

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f0e08eeb4833299c8a163f94574f9