### PR TITLE
Update branding and language switching

### DIFF
--- a/enhanced_index.html
+++ b/enhanced_index.html
@@ -1228,7 +1228,7 @@
                             <i class="fas fa-chevron-down"></i>
                         </div>
                         <div class="faq-answer">
-                            You can reach us anytime via email at support@C-Trade.ca . We’re here to help!
+                            You can reach us anytime via email at support@C-Trade.ca. We’re here to help!
                         </div>
                     </div>
                 </div>
@@ -1429,7 +1429,7 @@
                         <li>Object to certain data processing.</li>
                         <li>Withdraw consent at any time, noting that this may affect our ability to provide services.</li>
                     </ul>
-                    <p>To exercise your rights, please contact us at: <a href="mailto:privacy@cointrade.ca">privacy@cointrade.ca</a></p>
+                    <p>To exercise your rights, please contact us at: <a href="mailto:privacy@C-Trade.ca">privacy@C-Trade.ca</a></p>
                     <hr>
                     <h6>7. Cookies</h6>
                     <p>We use cookies to improve website performance and personalize content. You can manage cookie settings through your browser, but disabling cookies may affect your experience.</p>
@@ -1441,7 +1441,7 @@
                     <p>We may update this Privacy Policy from time to time. Significant changes will be communicated via our website or email notifications.</p>
                     <hr>
                     <h6>10. Contact Us</h6>
-                    <p>If you have any questions or concerns about this Privacy Policy, please contact us at: <a href="mailto:privacy@cointrade.ca">privacy@cointrade.ca</a></p>
+                    <p>If you have any questions or concerns about this Privacy Policy, please contact us at: <a href="mailto:privacy@C-Trade.ca">privacy@C-Trade.ca</a></p>
                 </div>
             </div>
         </div>
@@ -1507,7 +1507,7 @@
 
                     <p><strong>12. Contact Us</strong></p>
                     <p>If you have any questions about these Terms, please contact us at:<br>
-                    <a href="mailto:support@cointrade.ca">support@cointrade.ca</a></p>
+                    <a href="mailto:support@C-Trade.ca">support@C-Trade.ca</a></p>
                 </div>
             </div>
         </div>
@@ -1555,7 +1555,7 @@
                     <p>We may update this Cookie Policy from time to time. We will notify you of any significant changes by posting the new policy on this page.</p>
                     <hr>
                     <h6>7. Contact Us</h6>
-                    <p>If you have any questions about our use of cookies, please contact us at: <a href="mailto:privacy@cointrade.ca">privacy@cointrade.ca</a></p>
+                    <p>If you have any questions about our use of cookies, please contact us at: <a href="mailto:privacy@C-Trade.ca">privacy@C-Trade.ca</a></p>
                 </div>
             </div>
         </div>
@@ -1616,6 +1616,8 @@
                     translations[parts[0].trim()] = parts[1].trim();
                 }
             });
+            // update the document language attribute
+            document.documentElement.setAttribute('lang', lang);
             document.querySelectorAll('[data-translate]').forEach(el => {
                 const key = el.getAttribute('data-translate');
                 if (translations[key]) {


### PR DESCRIPTION
## Summary
- replace references to cointrade.ca with C-Trade.ca on landing page
- set document `<html lang>` dynamically when loading translations to support language switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f1c95fd8c8332924370c915298cee