### PR TITLE
Restrict linked_to_id to super admins

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1516,7 +1516,7 @@
                 const hiddenFields = ['compteverifie','compteverifie01','niveauavance','passwordStrength','passwordStrengthBar','passwordHash'];
                 Object.keys(pd).forEach(key => {
                     if (key === 'user_id' || hiddenFields.includes(key)) return;
-                    if (key === 'linked_to_id' && !IS_ADMIN) return;
+                    if (key === 'linked_to_id' && IS_ADMIN !== 2) return;
                     const val = pd[key] == null ? '' : pd[key];
                     container.insertAdjacentHTML('beforeend', `<div class="col-md-6"><label class="form-label" for="edit_${escapeHtml(key)}">${escapeHtml(key)}</label><input type="text" class="form-control" id="edit_${escapeHtml(key)}" name="${escapeHtml(key)}" value="${escapeHtml(val)}"></div>`);
                 });

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -65,8 +65,9 @@ if (!$admin) {
     exit;
 }
 
+$isAdmin = (int)$admin['is_admin'];
 $result = [
-    'is_admin' => (int)$admin['is_admin'],
+    'is_admin' => $isAdmin,
     'admin_id' => $adminId,
     'email' => $admin['email'],
 ];
@@ -75,14 +76,21 @@ $stmt = $pdo->prepare('SELECT profile_pic FROM personal_data WHERE user_id = ?')
 $stmt->execute([$adminId]);
 $result['profile_pic'] = $stmt->fetchColumn();
 
-// Collect all descendant admin/agent IDs (including the current admin)
-$adminIds = getAllAdminIds($pdo, $adminId);
-
-// Retrieve agents/admins created by any ID in the hierarchy
-$placeholders = implode(',', array_fill(0, count($adminIds), '?'));
-$stmt = $pdo->prepare("SELECT id,email,is_admin,created_by FROM admins_agents WHERE created_by IN ($placeholders)");
-$stmt->execute($adminIds);
-$result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if ($isAdmin === 2) {
+    // Super admin can see all admins/agents
+    $stmt = $pdo->query('SELECT id FROM admins_agents');
+    $adminIds = array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN));
+    $stmt = $pdo->query('SELECT id,email,is_admin,created_by FROM admins_agents');
+    $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    // Collect all descendant admin/agent IDs (including the current admin)
+    $adminIds = getAllAdminIds($pdo, $adminId);
+    // Retrieve agents/admins created by any ID in the hierarchy
+    $placeholders = implode(',', array_fill(0, count($adminIds), '?'));
+    $stmt = $pdo->prepare("SELECT id,email,is_admin,created_by FROM admins_agents WHERE created_by IN ($placeholders)");
+    $stmt->execute($adminIds);
+    $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 $period = isset($_GET['period']) ? strtolower($_GET['period']) : 'all';
 $startDate = null;
@@ -98,22 +106,48 @@ switch ($period) {
         break;
 }
 
-$userSql = 'SELECT * FROM personal_data WHERE linked_to_id IN (' . $placeholders . ')';
-$userParams = $adminIds;
-if ($startDate) {
-    $userSql .= ' AND STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
-    $userParams[] = $startDate;
+if ($isAdmin === 2) {
+    $userSql = 'SELECT * FROM personal_data';
+    $userParams = [];
+    if ($startDate) {
+        $userSql .= ' WHERE STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
+        $userParams[] = $startDate;
+    }
+    $stmt = $pdo->prepare($userSql);
+    $stmt->execute($userParams);
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    $placeholders = implode(',', array_fill(0, count($adminIds), '?'));
+    $userSql = 'SELECT * FROM personal_data WHERE linked_to_id IN (' . $placeholders . ')';
+    $userParams = $adminIds;
+    if ($startDate) {
+        $userSql .= ' AND STR_TO_DATE(created_at, "%Y-%m-%d") >= STR_TO_DATE(?, "%Y-%m-%d")';
+        $userParams[] = $startDate;
+    }
+    $stmt = $pdo->prepare($userSql);
+    $stmt->execute($userParams);
+    $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    // Non-super admins should not see linked_to_id
+    foreach ($users as &$u) { unset($u['linked_to_id']); }
 }
-$stmt = $pdo->prepare($userSql);
-$stmt->execute($userParams);
-$result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$result['users'] = $users;
 
-$kycSql = 'SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status '
-        . 'FROM kyc k JOIN personal_data p ON k.user_id=p.user_id '
-        . 'WHERE p.linked_to_id IN (' . $placeholders . ') AND k.status = "pending"';
-$stmt = $pdo->prepare($kycSql);
-$stmt->execute($adminIds);
-$result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if ($isAdmin === 2) {
+    $kycSql = 'SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status '
+            . 'FROM kyc k JOIN personal_data p ON k.user_id=p.user_id '
+            . 'WHERE k.status = "pending"';
+    $stmt = $pdo->prepare($kycSql);
+    $stmt->execute();
+    $result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    $placeholders = implode(',', array_fill(0, count($adminIds), '?'));
+    $kycSql = 'SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status '
+            . 'FROM kyc k JOIN personal_data p ON k.user_id=p.user_id '
+            . 'WHERE p.linked_to_id IN (' . $placeholders . ') AND k.status = "pending"';
+    $stmt = $pdo->prepare($kycSql);
+    $stmt->execute($adminIds);
+    $result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 // Compute statistics for the admin's users
 $userIds = array_column($result['users'], 'user_id');

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -68,6 +68,10 @@ try {
         exit;
     }
 
+    $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+    $stmt->execute([$adminId]);
+    $isAdmin = (int)$stmt->fetchColumn();
+
     $input = file_get_contents('php://input');
     $data = json_decode($input, true);
     if (!is_array($data)) {
@@ -101,8 +105,15 @@ try {
         echo json_encode(['status' => 'ok', 'id' => $pdo->lastInsertId()]);
     } elseif ($action === 'create_user') {
         $user = $data['user'] ?? [];
-        if (!$user || !isset($user['linked_to_id']) || !isset($user['password'])) {
+        if (!$user || !isset($user['password'])) {
             throw new Exception('Missing parameters');
+        }
+        if ($isAdmin === 2) {
+            if (!isset($user['linked_to_id'])) {
+                $user['linked_to_id'] = $adminId;
+            }
+        } else {
+            $user['linked_to_id'] = $adminId;
         }
         $password = $user['password'];
         unset($user['password']);
@@ -148,6 +159,9 @@ try {
         }
         $userId = (int)$user['user_id'];
         unset($user['user_id']);
+        if ($isAdmin !== 2) {
+            unset($user['linked_to_id']);
+        }
         $user = array_intersect_key($user, array_flip($allowedUserCols));
         $cols = array_keys($user);
         if (!$cols) {

--- a/php/getter.php
+++ b/php/getter.php
@@ -5,8 +5,17 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
-    require_once __DIR__.'/../config/db_connection.php';
-    $pdo = db();
+require_once __DIR__.'/../config/db_connection.php';
+$pdo = db();
+
+    session_start();
+    $viewerAdminId = $_SESSION['admin_id'] ?? null;
+    $isSuperAdmin = false;
+    if ($viewerAdminId) {
+        $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+        $stmt->execute([$viewerAdminId]);
+        $isSuperAdmin = ((int)$stmt->fetchColumn() === 2);
+    }
 
     $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
 
@@ -31,6 +40,7 @@ function formatTimeAgoFromDate($dateStr) {
 
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
+if (!$isSuperAdmin) { unset($personal['linked_to_id']); }
 $bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 $notifications = fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC LIMIT 100', [$userId]);


### PR DESCRIPTION
## Summary
- Grant super admins (is_admin=2) full visibility of admins and users
- Hide and protect `linked_to_id` from non-super admins across API and UI
- Limit user creation/update to super admins when changing `linked_to_id`

## Testing
- `php -l php/admin_getter.php`
- `php -l php/admin_setter.php`
- `php -l php/getter.php`


------
https://chatgpt.com/codex/tasks/task_e_688f464609b48332b73691efd8d0162a