### PR TITLE
Fix KYC tab visibility and profile layout

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -1112,6 +1112,8 @@ Mon compte </button>
 <!-- Wallet section removed -->
 </div>
 </div>
+<!-- Close Profile Tab -->
+</div>
 <!-- Modal : Changer le mot de passe -->
 <div aria-hidden="true" aria-labelledby="changePasswordModalLabel" class="modal fade" id="changePasswordModal" tabindex="-1">
 <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- close profile tab div to keep KYC content visible
- tidy profile layout after removing wallet section

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689003760f94833294a90431609d59c3