### PR TITLE
feat: add USD-based market orders

### DIFF
--- a/php/market_order.php
+++ b/php/market_order.php
@@ -13,12 +13,13 @@ try {
         exit;
     }
 
-    $userId = isset($data['user_id']) ? (int)$data['user_id'] : 0;
-    $pair = $data['pair'] ?? '';
+    $userId   = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+    $pair     = $data['pair'] ?? '';
     $quantity = isset($data['quantity']) ? (float)$data['quantity'] : 0.0;
-    $side = strtolower($data['side'] ?? 'buy');
+    $amount   = isset($data['amount']) ? (float)$data['amount'] : 0.0; // USD amount
+    $side     = strtolower($data['side'] ?? 'buy');
 
-    if (!$userId || !$pair || $quantity <= 0 || !in_array($side, ['buy','sell'])) {
+    if (!$userId || !$pair || (!($quantity > 0) && !($amount > 0)) || !in_array($side, ['buy','sell'])) {
         http_response_code(400);
         echo json_encode(['status' => 'error', 'message' => 'Missing parameters']);
         exit;
@@ -35,6 +36,9 @@ try {
         http_response_code(500);
         echo json_encode(['status' => 'error', 'message' => 'Failed to fetch price']);
         exit;
+    }
+    if ($quantity <= 0 && $amount > 0) {
+        $quantity = $amount / $price;
     }
     $total = $price * $quantity;
 
@@ -55,20 +59,35 @@ try {
     }
     $pdo->commit();
     $newBalance = $result['balance'];
-    $opNum = $result['operation'];
-    $profit = $result['profit'];
-    $price = $result['price'];
+    $opNum      = $result['operation'];
+    $profit     = $result['profit'];
+    $price      = $result['price'];
 
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('balance_updated', ['newBalance' => $newBalance], $userId);
-    pushEvent('new_trade', [
-        'operation_number' => $opNum,
-        'pair' => $pair,
-        'side' => $side,
-        'quantity' => $quantity,
-        'price' => $price,
-        'profit_loss' => $profit
-    ], $userId);
+
+    if ($side === 'buy') {
+        // Notify frontend of the new open trade
+        pushEvent('new_trade', [
+            'operation_number' => $opNum,
+            'pair' => $pair,
+            'side' => $side,
+            'quantity' => $quantity,
+            'price' => $price,
+            'target_price' => $price,
+            'profit_loss' => $profit
+        ], $userId);
+    } else {
+        // Closing an existing trade
+        pushEvent('order_filled', [
+            'order_id' => ltrim($opNum, 'T'),
+            'pair' => $pair,
+            'side' => $side,
+            'quantity' => $quantity,
+            'price' => $price,
+            'profit_loss' => $profit
+        ], $userId);
+    }
 
     $actionMsg = $side === 'buy'
         ? "Achat de {$quantity} {$base} au prix du march\xC3\xA9 pour {$total} {$quote}"

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -12,6 +12,7 @@ try {
     $userId = (int)($input['user_id'] ?? 0);
     $pair = $input['pair'] ?? '';
     $qty = isset($input['quantity']) ? (float)$input['quantity'] : 0.0;
+    $amount = isset($input['amount']) ? (float)$input['amount'] : 0.0; // USD amount for market orders
     $side = strtolower($input['side'] ?? 'buy');
     $type = strtolower($input['type'] ?? 'market');
     if ($type === 'stoplimit') $type = 'stop_limit';
@@ -30,7 +31,9 @@ try {
     $trailPerc = $trailPerc !== null ? (float)$trailPerc : null;
     $stopPercent = $stopPercent !== null ? (float)$stopPercent : null;
 
-    if(!$userId || !$pair || !$isPositive($qty) || !in_array($side,['buy','sell'])){
+    $qtyProvided = $isPositive($qty);
+    $amtProvided = $isPositive($amount);
+    if(!$userId || !$pair || (!in_array($side,['buy','sell'])) || (!$qtyProvided && !($type==='market' && $amtProvided))){
         http_response_code(400);
         echo json_encode(['status'=>'error','message'=>'Missing parameters']);
         exit;
@@ -107,8 +110,21 @@ try {
     $pdo = db();
 
     $livePrice = getLivePrice($pair);
+    if($type==='market' && !$qtyProvided && $amtProvided){
+        if($livePrice<=0){
+            http_response_code(500);
+            echo json_encode(['status'=>'error','message'=>'Failed to fetch price']);
+            return;
+        }
+        $qty = $amount / $livePrice;
+        $qtyProvided = $isPositive($qty);
+        if(!$qtyProvided){
+            http_response_code(400);
+            echo json_encode(['status'=>'error','message'=>'Invalid amount']);
+            return;
+        }
+    }
     if($livePrice<=0) $livePrice = 0.0;
-
 
     // ensure sufficient balance for pending buy orders
     if($type!=='market' && $side==='buy'){
@@ -132,16 +148,33 @@ try {
         if(!$result['ok']){ $pdo->rollBack(); http_response_code(400); echo json_encode(['status'=>'error','message'=>$result['msg']]); return; }
         $pdo->commit();
         require_once __DIR__.'/../utils/poll.php';
+        $price   = $result['price'];
+        $profit  = $result['profit'];
+        $opNum   = $result['operation'];
         pushEvent('balance_updated', ['newBalance' => $result['balance']], $userId);
-        pushEvent('order_filled', [
-            'pair' => $pair,
-            'side' => $side,
-            'quantity' => $qty,
-            'price' => $result['price']
-        ], $userId);
+        if($side==='buy'){
+            pushEvent('new_trade', [
+                'operation_number' => $opNum,
+                'pair' => $pair,
+                'side' => $side,
+                'quantity' => $qty,
+                'price' => $price,
+                'target_price' => $price,
+                'profit_loss' => $profit
+            ], $userId);
+        } else {
+            pushEvent('order_filled', [
+                'order_id' => ltrim($opNum,'T'),
+                'pair' => $pair,
+                'side' => $side,
+                'quantity' => $qty,
+                'price' => $price,
+                'profit_loss' => $profit
+            ], $userId);
+        }
         echo json_encode([
             'status'=>'ok',
-            'price'=>$result['price'],
+            'price'=>$price,
             'new_balance'=>$result['balance']
         ]);
         return;

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -87,7 +87,9 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
         }
         $opNum = 'T'.($order['id'] ?: $tradeId);
-        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],$order['side'],$order['quantity'],$price,'complet');
+        // Record this trade as open in the trading history so that the UI can
+        // track its profit/loss over time until it is closed.
+        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],$order['side'],$order['quantity'],$price,'En cours');
         return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum];
     }
 


### PR DESCRIPTION
## Summary
- allow placing market orders using either coin quantity or USD amount
- record market buys as open trades so profit/loss updates until closed
- notify frontend appropriately when opening or closing market trades

## Testing
- `php -l utils/helpers.php`
- `php -l php/market_order.php`
- `php -l php/place_order.php`


------
https://chatgpt.com/codex/tasks/task_e_689005e29b988332964d062a43d294c3