### PR TITLE
Enable basic short selling support

### DIFF
--- a/php/market_order.php
+++ b/php/market_order.php
@@ -62,11 +62,12 @@ try {
     $opNum      = $result['operation'];
     $profit     = $result['profit'];
     $price      = $result['price'];
+    $opened     = $result['opened'];
 
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('balance_updated', ['newBalance' => $newBalance], $userId);
 
-    if ($side === 'buy') {
+    if ($opened) {
         // Notify frontend of the new open trade
         pushEvent('new_trade', [
             'operation_number' => $opNum,

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -151,8 +151,9 @@ try {
         $price   = $result['price'];
         $profit  = $result['profit'];
         $opNum   = $result['operation'];
+        $opened  = $result['opened'];
         pushEvent('balance_updated', ['newBalance' => $result['balance']], $userId);
-        if($side==='buy'){
+        if($opened){
             pushEvent('new_trade', [
                 'operation_number' => $opNum,
                 'pair' => $pair,

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -76,12 +76,34 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     $bal = (float)$st->fetchColumn();
     $total = $price * $order['quantity'];
 
+    // BUY orders either open a long position or close an existing short
     if ($order['side'] === 'buy') {
+        // First check for open short positions to close
+        $stOpen = $pdo->prepare('SELECT id,price,quantity FROM trades WHERE user_id=? AND pair=? AND side="sell" AND status="open" ORDER BY id ASC LIMIT 1');
+        $stOpen->execute([$order['user_id'],$order['pair']]);
+        $open = $stOpen->fetch(PDO::FETCH_ASSOC);
+        if ($open) {
+            if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
+            $deposit = $open['price'] * $order['quantity'];
+            $profit  = ($open['price'] - $price) * $order['quantity'];
+            $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$deposit + $profit, $order['user_id']]);
+            $remaining = $open['quantity'] - $order['quantity'];
+            if ($remaining > 0) {
+                $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);
+            } else {
+                $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')->execute([$price,$profit,$open['id']]);
+            }
+            $opNum = 'T'.$open['id'];
+            addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
+            return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
+        }
+
+        // No short to close - open a long position
         if ($bal < $total) return ['ok' => false, 'msg' => 'Solde insuffisant'];
         $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total, $order['user_id']]);
         $orderId = empty($order['id']) ? null : $order['id'];
         $stmt = $pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss,status) VALUES (?,?,?,?,?,?,?,0,0,"open")');
-        $stmt->execute([$order['user_id'],$orderId,$order['pair'],$order['side'],$order['quantity'],$price,$total]);
+        $stmt->execute([$order['user_id'],$orderId,$order['pair'],'buy',$order['quantity'],$price,$total]);
         $tradeId = $pdo->lastInsertId();
         if ($orderId !== null) {
             $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
@@ -89,24 +111,43 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $opNum = 'T'.($order['id'] ?: $tradeId);
         // Record this trade as open in the trading history so that the UI can
         // track its profit/loss over time until it is closed.
-        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],$order['side'],$order['quantity'],$price,'En cours');
-        return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum];
+        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'En cours');
+        return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true];
     }
 
-    $stOpen=$pdo->prepare('SELECT id,price,quantity FROM trades WHERE user_id=? AND pair=? AND status="open" ORDER BY id ASC LIMIT 1');
+    // SELL orders either close a long position or open a new short
+    $stOpen = $pdo->prepare('SELECT id,price,quantity,side FROM trades WHERE user_id=? AND pair=? AND status="open" ORDER BY id ASC LIMIT 1');
     $stOpen->execute([$order['user_id'],$order['pair']]);
-    $open=$stOpen->fetch(PDO::FETCH_ASSOC);
-    if(!$open || $open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
-    $profit=($price-$open['price'])*$order['quantity'];
-    $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);
-    $remaining=$open['quantity']-$order['quantity'];
-    if($remaining>0){
-        $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining,$remaining*$open['price'],$profit,$open['id']]);
-    }else{
-        $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')->execute([$price,$profit,$open['id']]);
+    $open = $stOpen->fetch(PDO::FETCH_ASSOC);
+
+    if ($open && $open['side'] === 'buy') {
+        // Closing a long position
+        if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
+        $profit = ($price - $open['price']) * $order['quantity'];
+        $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);
+        $remaining = $open['quantity'] - $order['quantity'];
+        if ($remaining > 0) {
+            $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);
+        } else {
+            $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')->execute([$price,$profit,$open['id']]);
+        }
+        $opNum = 'T'.$open['id'];
+        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
+        return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
     }
-    $opNum='T'.$open['id'];
-    addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
-    return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum];
+
+    // No long position to close - open a short position
+    if ($bal < $total) return ['ok' => false, 'msg' => 'Solde insuffisant'];
+    $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total, $order['user_id']]);
+    $orderId = empty($order['id']) ? null : $order['id'];
+    $stmt = $pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss,status) VALUES (?,?,?,?,?,?,?,0,0,"open")');
+    $stmt->execute([$order['user_id'],$orderId,$order['pair'],'sell',$order['quantity'],$price,$total]);
+    $tradeId = $pdo->lastInsertId();
+    if ($orderId !== null) {
+        $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
+    }
+    $opNum = 'T'.($order['id'] ?: $tradeId);
+    addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours');
+    return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true];
 }
 ?>


### PR DESCRIPTION
## Summary
- allow executeTrade to open and close short positions
- notify frontend differently for trade openings vs closings

## Testing
- `php -l coin/utils/helpers.php`
- `php -l coin/php/market_order.php`
- `php -l coin/php/place_order.php`


------
https://chatgpt.com/codex/tasks/task_e_689015f887e88332b7d61f31f07ee4fe