### PR TITLE
Fix array to string conversion in setter

### DIFF
--- a/php/setter.php
+++ b/php/setter.php
@@ -24,6 +24,14 @@ try {
         $personal = $data['personalData'];
         $personal['user_id'] = $userId;
 
+        // Remove any array or object values. These can appear from
+        // frontend helpers (e.g. wallets) and cause "Array to string
+        // conversion" errors when binding parameters.
+        $personal = array_filter(
+            $personal,
+            fn($v) => !is_array($v) && !is_object($v)
+        );
+
         $cols = array_keys($personal);
         $place = implode(',', array_fill(0, count($cols), '?'));
         $update = implode(',', array_map(fn($c) => "$c = VALUES($c)", $cols));


### PR DESCRIPTION
## Summary
- guard against array/object values when saving personal data to avoid array-to-string errors

## Testing
- `php -l php/setter.php`
- `find php -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68902323f4608332adc0ef24b4f9ab28