### PR TITLE
Restrict linked_to_id access to super admin

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1516,7 +1516,7 @@
                 const hiddenFields = ['compteverifie','compteverifie01','niveauavance','passwordStrength','passwordStrengthBar','passwordHash'];
                 Object.keys(pd).forEach(key => {
                     if (key === 'user_id' || hiddenFields.includes(key)) return;
-                    if (key === 'linked_to_id' && !IS_ADMIN) return;
+                    if (key === 'linked_to_id' && IS_ADMIN !== 2) return;
                     const val = pd[key] == null ? '' : pd[key];
                     container.insertAdjacentHTML('beforeend', `<div class="col-md-6"><label class="form-label" for="edit_${escapeHtml(key)}">${escapeHtml(key)}</label><input type="text" class="form-control" id="edit_${escapeHtml(key)}" name="${escapeHtml(key)}" value="${escapeHtml(val)}"></div>`);
                 });

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -132,6 +132,13 @@ if ((int)$admin['is_admin'] === 2) {
     $result['users'] = $users;
 }
 
+if ((int)$admin['is_admin'] !== 2) {
+    foreach ($result['users'] as &$u) {
+        unset($u['linked_to_id']);
+    }
+    unset($u);
+}
+
 if ((int)$admin['is_admin'] === 2) {
     $stmt = $pdo->query('SELECT k.file_id,k.user_id,p.fullName,p.emailaddress,k.file_name,k.file_type,k.created_at,k.status FROM kyc k JOIN personal_data p ON k.user_id=p.user_id WHERE k.status = "pending"');
 } else {

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -67,6 +67,10 @@ try {
         exit;
     }
 
+    $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+    $stmt->execute([$adminId]);
+    $isAdmin = (int)$stmt->fetchColumn();
+
     $input = file_get_contents('php://input');
     $data = json_decode($input, true);
     if (!is_array($data)) {
@@ -100,8 +104,13 @@ try {
         echo json_encode(['status' => 'ok', 'id' => $pdo->lastInsertId()]);
     } elseif ($action === 'create_user') {
         $user = $data['user'] ?? [];
-        if (!$user || !isset($user['linked_to_id']) || !isset($user['password'])) {
+        if (!$user || !isset($user['password'])) {
             throw new Exception('Missing parameters');
+        }
+        if ($isAdmin !== 2) {
+            $user['linked_to_id'] = $adminId;
+        } elseif (!isset($user['linked_to_id'])) {
+            throw new Exception('Missing linked_to_id');
         }
         $password = $user['password'];
         unset($user['password']);
@@ -147,6 +156,9 @@ try {
         }
         $userId = (int)$user['user_id'];
         unset($user['user_id']);
+        if ($isAdmin !== 2 && isset($user['linked_to_id'])) {
+            unset($user['linked_to_id']);
+        }
         $user = array_intersect_key($user, array_flip($allowedUserCols));
         $cols = array_keys($user);
         if (!$cols) {

--- a/php/getter.php
+++ b/php/getter.php
@@ -11,6 +11,21 @@ try {
 
     $userId = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 1;
 
+    $adminId = null;
+    session_start();
+    if (isset($_SESSION['admin_id'])) {
+        $adminId = (int)$_SESSION['admin_id'];
+    } elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
+              preg_match('/Bearer\s+(\d+)/i', $_SERVER['HTTP_AUTHORIZATION'], $m)) {
+        $adminId = (int)$m[1];
+    }
+    $adminRole = 0;
+    if ($adminId) {
+        $stmt = $pdo->prepare('SELECT is_admin FROM admins_agents WHERE id = ?');
+        $stmt->execute([$adminId]);
+        $adminRole = (int)$stmt->fetchColumn();
+    }
+
 function fetchAll($pdo, $sql, $params = []) {
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
@@ -32,6 +47,9 @@ function formatTimeAgoFromDate($dateStr) {
 
 $personal = fetchAll($pdo, 'SELECT * FROM personal_data WHERE user_id = ?', [$userId]);
 $personal = $personal ? $personal[0] : [];
+if ($adminRole !== 2) {
+    unset($personal['linked_to_id']);
+}
 $bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
 $notifications = fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC LIMIT 100', [$userId]);


### PR DESCRIPTION
## Summary
- Only super admins can view and edit a user's `linked_to_id` field
- Enforce server-side checks to prevent non-super admins from modifying `linked_to_id`
- Hide `linked_to_id` from non-super admins in admin and user getters

## Testing
- `php -l php/admin_setter.php`
- `php -l php/admin_getter.php`
- `php -l php/getter.php`


------
https://chatgpt.com/codex/tasks/task_e_68903aed92e483328ef29fe8de76fe42