### PR TITLE
Process pending orders via cron and remove duplicate OCO toggle

### DIFF
--- a/cron/cron_process_orders.php
+++ b/cron/cron_process_orders.php
@@ -5,6 +5,23 @@ require_once __DIR__.'/../utils/helpers.php';
 
 $pdo = db();
 
+function fillOrder(PDO $pdo, array $o, float $price): void {
+    $pdo->beginTransaction();
+    $res = executeTrade($pdo, $o, $price);
+    if ($res['ok']) {
+        $pdo->commit();
+        require_once __DIR__ . '/../utils/poll.php';
+        pushEvent('balance_updated', ['newBalance' => $res['balance']], $o['user_id']);
+        pushEvent('order_filled', ['order_id' => $o['id'], 'price' => $res['price']], $o['user_id']);
+        if (!empty($o['related_order_id'])) {
+            $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=?")
+                ->execute([$o['related_order_id']]);
+        }
+    } else {
+        $pdo->rollBack();
+    }
+}
+
 // fetch open and triggered orders
 $orders = $pdo->query("SELECT * FROM orders WHERE status IN ('open','triggered')")->fetchAll(PDO::FETCH_ASSOC);
 foreach ($orders as $o) {
@@ -14,16 +31,7 @@ foreach ($orders as $o) {
     switch ($o['type']) {
         case 'limit':
             if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
-                $pdo->beginTransaction();
-                $res = executeTrade($pdo, $o, $price);
-                if ($res['ok']) {
-                    $pdo->commit();
-                    require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',[ 'newBalance'=>$res['balance'] ],$o['user_id']);
-                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                } else {
-                    $pdo->rollBack();
-                }
+                fillOrder($pdo, $o, $price);
             }
             break;
         case 'percentage_stop':
@@ -31,73 +39,28 @@ foreach ($orders as $o) {
             if ($o['side']=='sell') {
                 $threshold *= (1 - $o['stop_percentage']/100);
                 if ($price <= $threshold) {
-                    $pdo->beginTransaction();
-                    $res=executeTrade($pdo,$o,$price);
-                    if($res['ok']) {
-                        $pdo->commit();
-                        require_once __DIR__.'/../utils/poll.php';
-                        pushEvent('balance_updated',[ 'newBalance'=>$res['balance'] ],$o['user_id']);
-                        pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                    } else {
-                        $pdo->rollBack();
-                    }
+                    fillOrder($pdo, $o, $price);
                 }
             } else {
                 $threshold *= (1 + $o['stop_percentage']/100);
                 if ($price >= $threshold) {
-                    $pdo->beginTransaction();
-                    $res=executeTrade($pdo,$o,$price);
-                    if($res['ok']) {
-                        $pdo->commit();
-                        require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',[ 'newBalance'=>$res['balance'] ],$o['user_id']);
-                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                    } else {
-                        $pdo->rollBack();
-                    }
+                    fillOrder($pdo, $o, $price);
                 }
             }
             break;
         case 'time_stop':
             if (strtotime($o['stop_time']) <= time()) {
-                $pdo->beginTransaction();
-                $res=executeTrade($pdo,$o,$price);
-                if($res['ok']) {
-                    $pdo->commit();
-                    require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',[ 'newBalance'=>$res['balance'] ],$o['user_id']);
-                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                } else {
-                    $pdo->rollBack();
-                }
+                fillOrder($pdo, $o, $price);
             }
             break;
         case 'oco':
             if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
-                $pdo->beginTransaction();
-                $res = executeTrade($pdo, $o, $price);
-                if ($res['ok']) {
-                    $pdo->commit();
-                    require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
-                    pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                } else {
-                    $pdo->rollBack();
-                }
+                fillOrder($pdo, $o, $price);
             }
             break;
         case 'stop':
             if (($o['side']=='buy' && $price >= $o['stop_price']) || ($o['side']=='sell' && $price <= $o['stop_price'])) {
-                $pdo->beginTransaction();
-                $res = executeTrade($pdo, $o, $price);
-                if ($res['ok']) {
-                    $pdo->commit();
-                    require_once __DIR__.'/../utils/poll.php';
-                    pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
-                    pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$price],$o['user_id']);
-                } else {
-                    $pdo->rollBack();
-                }
+                fillOrder($pdo, $o, $price);
             }
             break;
         case 'stop_limit':
@@ -109,16 +72,7 @@ foreach ($orders as $o) {
             }
             if ($o['status']=='triggered') {
                 if (($o['side']=='buy' && $price <= $o['target_price']) || ($o['side']=='sell' && $price >= $o['target_price'])) {
-                    $pdo->beginTransaction();
-                    $res = executeTrade($pdo,$o,$price);
-                    if ($res['ok']) {
-                        $pdo->commit();
-                        require_once __DIR__.'/../utils/poll.php';
-                        pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
-                        pushEvent('order_filled',[ 'order_id'=>$o['id'],'price'=>$price ],$o['user_id']);
-                    } else {
-                        $pdo->rollBack();
-                    }
+                    fillOrder($pdo, $o, $price);
                 }
             }
             break;
@@ -128,32 +82,14 @@ foreach ($orders as $o) {
                     $pdo->prepare('UPDATE orders SET trail_price=? WHERE id=?')->execute([$price,$o['id']]);
                     $o['trail_price']=$price;
                 } elseif ($price <= $o['trail_price']*(1-$o['trailing_percentage']/100)) {
-                    $pdo->beginTransaction();
-                    $res=executeTrade($pdo,$o,$price);
-                    if($res['ok']) {
-                        $pdo->commit();
-                        require_once __DIR__.'/../utils/poll.php';
-                        pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
-                        pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$price],$o['user_id']);
-                    } else {
-                        $pdo->rollBack();
-                    }
+                    fillOrder($pdo, $o, $price);
                 }
             } else {
                 if ($price < $o['trail_price']) {
                     $pdo->prepare('UPDATE orders SET trail_price=? WHERE id=?')->execute([$price,$o['id']]);
                     $o['trail_price']=$price;
                 } elseif ($price >= $o['trail_price']*(1+$o['trailing_percentage']/100)) {
-                    $pdo->beginTransaction();
-                    $res=executeTrade($pdo,$o,$price);
-                    if($res['ok']) {
-                        $pdo->commit();
-                        require_once __DIR__.'/../utils/poll.php';
-                        pushEvent('balance_updated',['newBalance'=>$res['balance']],$o['user_id']);
-                        pushEvent('order_filled',['order_id'=>$o['id'],'price'=>$price],$o['user_id']);
-                    } else {
-                        $pdo->rollBack();
-                    }
+                    fillOrder($pdo, $o, $price);
                 }
             }
             break;

--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -322,17 +322,6 @@ Mon compte </button>
 <label class="form-label" for="stopLossTime">Heure d'arrêt du trading</label>
 <input class="form-control" id="stopLossTime" type="datetime-local"/>
 </div>
-<div class="form-check mb-3">
-<input class="form-check-input" id="enableOCO" type="checkbox"/>
-<label class="form-check-label" for="enableOCO"> Activer OCO (take profit + stop loss)</label>
-</div>
-<div class="mb-3" id="takeProfitDiv" style="display: none;">
-<label class="form-label" for="takeProfitPrice">Prix take profit</label>
-<div class="input-group">
-<input class="form-control" name="takeProfitPrice" id="takeProfitPrice" placeholder="Entrez le prix" step="0.01" type="number"/>
-<span class="input-group-text">USD</span>
-</div>
-</div>
 <button class="btn btn-warning btn-sm w-100" id="setStopLoss" type="button">
 <i class="fas fa-save me-2"></i>Enregistrer les paramètres du stop loss </button>
 </div>

--- a/script.js
+++ b/script.js
@@ -13,10 +13,6 @@ $(function() {
 
     $('#stopLossType').on('change', updateStopLossFields);
 
-    $('#enableOCO').on('change', function() {
-        $('#takeProfitDiv').toggle(this.checked);
-    });
-
     function updateTradeAmountCurrency() {
         const pairText = $('#currencyPair option:selected').text() || '';
         const parts = pairText.split('/');


### PR DESCRIPTION
## Summary
- use a common helper in `cron_process_orders.php` so limit, stop, stop-limit, trailing stop and OCO orders execute like market orders
- drop redundant OCO checkbox from stop-loss UI and associated JS

## Testing
- `php -l cron/cron_process_orders.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68904426475083329b191feca47e123a