### PR TITLE
feat: allow admin to block pending orders

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -719,7 +719,7 @@
                     <h6 class="mt-3">Historique de Trading</h6>
                     <table class="table table-sm">
                         <thead>
-                            <tr><th>Temps</th><th>Paire</th><th>Type</th><th>Montant</th><th>Prix</th><th>Statut</th><th>Profit/Perte</th></tr>
+                            <tr><th>Temps</th><th>Paire</th><th>Type</th><th>Montant</th><th>Prix</th><th>Statut</th><th>Profit/Perte</th><th>Action</th></tr>
                         </thead>
                         <tbody id="viewTrading"></tbody>
                     </table>
@@ -1500,9 +1500,33 @@
                 (data.tradingHistory || []).slice(0,10).forEach(t => {
                     const profit = t.profitPerte == null ? '-' : formatDollar(t.profitPerte);
                     const baseCoin = (t.paireDevises || '').split('/')[0];
-                    tradeBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(t.temps)}</td><td>${escapeHtml(t.paireDevises)}</td><td><span class="badge ${escapeHtml(t.statutTypeClass)}">${escapeHtml(t.type)}</span></td><td>${formatCrypto(t.montant)} ${escapeHtml(baseCoin)}</td><td>${formatDollar(t.prix)}</td><td><span class="badge ${escapeHtml(t.statutClass)}">${escapeHtml(t.statut)}</span></td><td class="${escapeHtml(t.profitClass || '')}">${profit}</td></tr>`);
+                    const isBlocked = Number(t.blocked) === 1;
+                    const action = t.statut === 'En cours'
+                        ? `<button class="btn btn-sm ${isBlocked ? 'btn-secondary' : 'btn-warning'} block-order-btn" data-id="${escapeHtml(t.order_id)}" data-blocked="${isBlocked ? 1 : 0}" title="${isBlocked ? 'Débloquer' : 'Bloquer'}"><i class="fas ${isBlocked ? 'fa-lock' : 'fa-lock-open'}"></i></button>`
+                        : '-';
+                    tradeBody.insertAdjacentHTML('beforeend', `<tr><td>${escapeHtml(t.temps)}</td><td>${escapeHtml(t.paireDevises)}</td><td><span class="badge ${escapeHtml(t.statutTypeClass)}">${escapeHtml(t.type)}</span></td><td>${formatCrypto(t.montant)} ${escapeHtml(baseCoin)}</td><td>${formatDollar(t.prix)}</td><td><span class="badge ${escapeHtml(t.statutClass)}">${escapeHtml(t.statut)}</span></td><td class="${escapeHtml(t.profitClass || '')}">${profit}</td><td>${action}</td></tr>`);
                 });
-                if (!tradeBody.innerHTML) tradeBody.innerHTML = '<tr><td colspan="7" class="text-center">Aucune donnée</td></tr>';
+                if (!tradeBody.innerHTML) tradeBody.innerHTML = '<tr><td colspan="8" class="text-center">Aucune donnée</td></tr>';
+                tradeBody.onclick = async function(ev){
+                    const btn = ev.target.closest('.block-order-btn');
+                    if (!btn) return;
+                    const id = btn.getAttribute('data-id');
+                    const blocked = btn.getAttribute('data-blocked') === '1';
+                    try {
+                        await fetchWithAuth('php/admin_setter.php', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ action: 'block_order', order_id: id, blocked: blocked ? 0 : 1 })
+                        });
+                        btn.setAttribute('data-blocked', blocked ? '0' : '1');
+                        btn.classList.toggle('btn-warning', blocked);
+                        btn.classList.toggle('btn-secondary', !blocked);
+                        btn.innerHTML = `<i class="fas ${blocked ? 'fa-lock-open' : 'fa-lock'}"></i>`;
+                        btn.title = blocked ? 'Bloquer' : 'Débloquer';
+                    } catch(err) {
+                        console.error('Failed to update order block', err);
+                    }
+                };
                 new bootstrap.Modal(document.getElementById('viewUserModal')).show();
             } else if (editBtn) {
                 const id = editBtn.getAttribute('data-id');

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1353,7 +1353,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td>${trade.statut==='En cours'?`<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`:'-'}</td>
+                        <td>${trade.statut==='En cours' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`) : '-'}</td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -312,6 +312,24 @@ try {
             $pdo->rollBack();
             throw $e;
         }
+    } elseif ($action === 'block_order') {
+        $orderId = isset($data['order_id']) ? (int)$data['order_id'] : 0;
+        $blocked = !empty($data['blocked']) ? 1 : 0;
+        if (!$orderId) {
+            throw new Exception('Missing parameters');
+        }
+        $stmt = $pdo->prepare('UPDATE orders SET blocked = ? WHERE id = ?');
+        $stmt->execute([$blocked, $orderId]);
+        $op = 'T' . $orderId;
+        $stmt = $pdo->prepare('SELECT details FROM tradingHistory WHERE operationNumber = ?');
+        $stmt->execute([$op]);
+        $details = $stmt->fetchColumn();
+        $detArr = $details ? json_decode($details, true) : [];
+        if (!is_array($detArr)) { $detArr = []; }
+        $detArr['blocked'] = $blocked;
+        $pdo->prepare('UPDATE tradingHistory SET details = ? WHERE operationNumber = ?')
+            ->execute([json_encode($detArr), $op]);
+        echo json_encode(['status' => 'ok']);
     } elseif ($action === 'edit_transaction_amount') {
         $op = isset($data['operationNumber']) ? trim($data['operationNumber']) : '';
         $amount = isset($data['amount']) ? (float)$data['amount'] : null;

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -29,6 +29,12 @@ try{
         echo json_encode(['status'=>'error','message'=>'Order not cancellable']);
         exit;
     }
+    if(!empty($order['blocked'])){
+        $pdo->rollBack();
+        http_response_code(403);
+        echo json_encode(['status'=>'error','message'=>'Order blocked']);
+        exit;
+    }
     $pdo->prepare('UPDATE orders SET status="cancelled" WHERE id=?')->execute([$orderId]);
     if (!empty($order['related_order_id'])) {
         $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=? AND status IN ('open','triggered')")

--- a/php/getter.php
+++ b/php/getter.php
@@ -109,6 +109,7 @@ foreach ($openTrades as &$t) {
     $t['unrealized_pnl'] = ($current - $t['price']) * $t['quantity'] * $sign;
 }
 unset($t);
+$blockStmt = $pdo->prepare('SELECT blocked FROM orders WHERE id = ?');
 
 $data = [
     'personalData' => $personal,
@@ -117,10 +118,14 @@ $data = [
     'notifications' => $notifications,
     'deposits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM deposits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
     'retraits' => fetchAll($pdo, 'SELECT operationNumber,date,amount,method,status,statusClass FROM retraits WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 10', [$userId]),
-    'tradingHistory' => array_map(function($r){
+    'tradingHistory' => array_map(function($r) use ($blockStmt){
         if (!empty($r['details'])) {
             $d = json_decode($r['details'], true);
             if (is_array($d)) { $r = array_merge($r, $d); }
+        }
+        if (!empty($r['order_id'])) {
+            $blockStmt->execute([$r['order_id']]);
+            $r['blocked'] = (int)$blockStmt->fetchColumn();
         }
         unset($r['details']);
         return $r;

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -189,6 +189,7 @@ CREATE TABLE orders (
     trail_price DECIMAL(20,10),
     related_order_id BIGINT,
     status ENUM('open','triggered','filled','cancelled') DEFAULT 'open',
+    blocked TINYINT(1) DEFAULT 0,
     price_at_execution DECIMAL(20,10),
     executed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- allow admins to block user orders directly from dashboard
- prevent users from cancelling blocked orders
- surface block status in API and UI

## Testing
- `php -l php/cancel_order.php`
- `php -l php/admin_setter.php`
- `php -l php/getter.php`


------
https://chatgpt.com/codex/tasks/task_e_68904f7273188332a941a821125d0a44