### PR TITLE
Fix limit order trigger logic

### DIFF
--- a/cron/cron_process_orders.php
+++ b/cron/cron_process_orders.php
@@ -25,8 +25,8 @@ function fillOrder(PDO $pdo, array $o, float $price): void {
 // ---- Order condition helpers ----
 
 function shouldFillLimit(array $o, float $price): bool {
-    return ($o['side'] === 'buy' && $price <= $o['target_price'])
-        || ($o['side'] === 'sell' && $price >= $o['target_price']);
+    return ($o['side'] === 'buy' && $price >= $o['target_price'])
+        || ($o['side'] === 'sell' && $price <= $o['target_price']);
 }
 
 function shouldFillStop(array $o, float $price): bool {


### PR DESCRIPTION
## Summary
- Correct limit order evaluation: execute buy orders when market price meets or exceeds the limit and sell orders when price meets or falls below the limit.

## Testing
- `php -l cron/cron_process_orders.php`


------
https://chatgpt.com/codex/tasks/task_e_689082fa51708332a8c8c408d7d66a65