### PR TITLE
Restrict stop button to market orders

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1353,7 +1353,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td>${trade.statut==='En cours' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`) : '-'}</td>
+                        <td>${trade.statut==='En cours' && trade.order_type==='market' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`) : '-'}</td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);
@@ -1723,7 +1723,7 @@ function initializeUI() {
         const op = $btn.data('op');
         const trade = (dashboardData.tradingHistory || []).find(t => t.operationNumber === op);
         const orderId = trade?.details?.order_id ?? trade?.order_id;
-        if (trade && trade.statut === 'En cours' && orderId) {
+        if (trade && trade.statut === 'En cours' && trade.order_type === 'market' && orderId) {
             const openTrade = (dashboardData.openTrades || []).find(t => t.id == orderId);
             try {
                 if (openTrade) {

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -29,6 +29,12 @@ try{
         echo json_encode(['status'=>'error','message'=>'Order not cancellable']);
         exit;
     }
+    if(($order['type'] ?? '') !== 'market'){
+        $pdo->rollBack();
+        http_response_code(403);
+        echo json_encode(['status'=>'error','message'=>'Only market orders can be cancelled']);
+        exit;
+    }
     if(!empty($order['blocked'])){
         $pdo->rollBack();
         http_response_code(403);

--- a/php/getter.php
+++ b/php/getter.php
@@ -109,7 +109,7 @@ foreach ($openTrades as &$t) {
     $t['unrealized_pnl'] = ($current - $t['price']) * $t['quantity'] * $sign;
 }
 unset($t);
-$blockStmt = $pdo->prepare('SELECT blocked FROM orders WHERE id = ?');
+$blockStmt = $pdo->prepare('SELECT blocked,type FROM orders WHERE id = ?');
 
 $data = [
     'personalData' => $personal,
@@ -125,7 +125,11 @@ $data = [
         }
         if (!empty($r['order_id'])) {
             $blockStmt->execute([$r['order_id']]);
-            $r['blocked'] = (int)$blockStmt->fetchColumn();
+            $row = $blockStmt->fetch(PDO::FETCH_ASSOC);
+            $r['blocked'] = (int)($row['blocked'] ?? 0);
+            if (isset($row['type'])) {
+                $r['order_type'] = $row['type'];
+            }
         }
         unset($r['details']);
         return $r;


### PR DESCRIPTION
## Summary
- Allow front-end to know each order's type
- Block cancellation of non-market orders
- Hide cancellation control unless order is market type

## Testing
- `php -l php/cancel_order.php`
- `php -l php/getter.php`
- `node --check js/updatePrices.js`

------
https://chatgpt.com/codex/tasks/task_e_689083d7b65883329897f28599b16b4a