### PR TITLE
Mark limit orders complete upon target fill

### DIFF
--- a/cron/cron_process_orders.php
+++ b/cron/cron_process_orders.php
@@ -12,7 +12,27 @@ function fillOrder(PDO $pdo, array $o, float $price): void {
         $pdo->commit();
         require_once __DIR__ . '/../utils/poll.php';
         pushEvent('balance_updated', ['newBalance' => $res['balance']], $o['user_id']);
-        pushEvent('order_filled', ['order_id' => $o['id'], 'price' => $res['price']], $o['user_id']);
+        if ($res['opened']) {
+            pushEvent('new_trade', [
+                'operation_number' => $res['operation'],
+                'pair' => $o['pair'],
+                'side' => $o['side'],
+                'quantity' => $o['quantity'],
+                'price' => $res['price'],
+                'target_price' => $res['price'],
+                'profit_loss' => $res['profit']
+            ], $o['user_id']);
+            pushEvent('order_filled', ['order_id' => $o['id'], 'price' => $res['price']], $o['user_id']);
+        } else {
+            pushEvent('order_filled', [
+                'order_id' => $o['id'],
+                'pair' => $o['pair'],
+                'side' => $o['side'],
+                'quantity' => $o['quantity'],
+                'price' => $res['price'],
+                'profit_loss' => $res['profit']
+            ], $o['user_id']);
+        }
         if (!empty($o['related_order_id'])) {
             $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=?")
                 ->execute([$o['related_order_id']]);

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -121,6 +121,10 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             }
             $opNum = 'T'.$open['id'];
             addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
+            if (!empty($order['id'])) {
+                $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
+                addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
+            }
             syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
             return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
         }
@@ -134,8 +138,9 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $tradeId = $pdo->lastInsertId();
         if ($orderId !== null) {
             $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
+            addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'buy',$order['quantity'],$price,'complet');
         }
-        $opNum = 'T'.($order['id'] ?: $tradeId);
+        $opNum = 'T'.$tradeId;
         // Record this trade as open in the trading history so that the UI can
         // track its profit/loss over time until it is closed.
         addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'En cours');
@@ -163,6 +168,10 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         }
         $opNum = 'T'.$open['id'];
         addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
+        if (!empty($order['id'])) {
+            $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
+            addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
+        }
         syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
         return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
     }
@@ -176,8 +185,9 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     $tradeId = $pdo->lastInsertId();
     if ($orderId !== null) {
         $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
+        addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'sell',$order['quantity'],$price,'complet');
     }
-    $opNum = 'T'.($order['id'] ?: $tradeId);
+    $opNum = 'T'.$tradeId;
     addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours');
     syncTransaction($pdo,$order['user_id'],$opNum,$total,'En cours');
     return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true];


### PR DESCRIPTION
## Summary
- Ensure that when a pending order hits its target, the corresponding order record is marked filled and logged as `complet`, while the resulting trade uses its own operation number.
- Emit full trade details when cron closes or opens orders so the frontend can both remove the order and show the new trade.

## Testing
- `php -l utils/helpers.php`
- `php -l cron/cron_process_orders.php`


------
https://chatgpt.com/codex/tasks/task_e_689089a5e08c83328bba61978f066a2b