### PR TITLE
Rename cancel column to Fermé in trading history

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -350,7 +350,7 @@ Mon compte </button>
 <th>Le prix</th>
 <th>Statut</th>
 <th>Profit/Perte</th>
-<th>Annuler</th>
+<th>Fermé</th>
 </tr>
 </thead>
 <tbody id="tradingHistory">

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1353,7 +1353,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td>${trade.statut==='En cours' && trade.order_type==='market' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`) : '-'}</td>
+                        <td>${trade.statut==='En cours' && trade.order_type==='market' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Fermé"><i class="fas fa-ban"></i></button>`) : '-'}</td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);


### PR DESCRIPTION
## Summary
- Rename trading history header from "Annuler" to "Fermé" and adjust cancel button tooltip.

## Testing
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_68909d8466b88332bf2e24ea1130dbbf