### PR TITLE
Implement dynamic market order profit tracking

### DIFF
--- a/cron/update_open_trades.php
+++ b/cron/update_open_trades.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../config/db_connection.php';
+require_once __DIR__ . '/../utils/helpers.php';
+require_once __DIR__ . '/../utils/poll.php';
+
+$pdo = db();
+$trades = $pdo->query("SELECT id,user_id,pair,side,quantity,price FROM trades WHERE status='open'")
+    ->fetchAll(PDO::FETCH_ASSOC);
+
+foreach ($trades as $t) {
+    $livePrice = getLivePrice($t['pair']);
+    if ($livePrice <= 0) {
+        continue;
+    }
+    if ($t['side'] === 'buy') {
+        $profit = ($livePrice - $t['price']) * $t['quantity'];
+    } else {
+        $profit = ($t['price'] - $livePrice) * $t['quantity'];
+    }
+    $pdo->prepare('UPDATE trades SET profit_loss=? WHERE id=?')->execute([$profit, $t['id']]);
+    pushEvent('trade_update', [
+        'operation_number' => 'T' . $t['id'],
+        'pair' => $t['pair'],
+        'price' => $livePrice,
+        'profit_loss' => $profit
+    ], $t['user_id']);
+}

--- a/js/longPollClient.js
+++ b/js/longPollClient.js
@@ -32,7 +32,13 @@ function handleEvents(response) {
         }
         break;
       case 'new_trade':
-        if (window.addTrade) window.addTrade(ev.data);
+        if (window.addTrade) {
+          const d = ev.data;
+          if (d.operation_number && !d.operationNumber) {
+            d.operationNumber = d.operation_number;
+          }
+          window.addTrade(d);
+        }
         break;
       case 'order_filled':
         if (window.handleOrderFilled) window.handleOrderFilled(ev.data);
@@ -42,6 +48,9 @@ function handleEvents(response) {
         break;
       case 'order_cancelled':
         if (window.handleOrderCancelled) window.handleOrderCancelled(ev.data);
+        break;
+      case 'trade_update':
+        if (window.handleTradeUpdate) window.handleTradeUpdate(ev.data);
         break;
       default:
         break;

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1518,6 +1518,15 @@ function initializeUI() {
         }
     };
 
+    window.handleTradeUpdate = function(data) {
+        const order = (dashboardData.tradingHistory || []).find(t => t.operationNumber === data.operation_number);
+        if (order) {
+            order.profitPerte = data.profit_loss;
+            order.profitClass = data.profit_loss >= 0 ? 'text-success' : 'text-danger';
+            renderTradingHistory();
+        }
+    };
+
     function finalizeOrder(order, exitPrice) {
         const priceValue = parseFloat(order.prix);
         const qty = parseFloat(order.montant);

--- a/php/market_order.php
+++ b/php/market_order.php
@@ -63,6 +63,8 @@ try {
     $profit     = $result['profit'];
     $price      = $result['price'];
     $opened     = $result['opened'];
+    $quantity   = $result['quantity'];
+    $total      = $price * $quantity;
 
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('balance_updated', ['newBalance' => $newBalance], $userId);

--- a/run_cron_jobs.bat
+++ b/run_cron_jobs.bat
@@ -4,5 +4,6 @@ cd /d "%~dp0"
 
 :loop
 php cron\cron_process_orders.php
+php cron\update_open_trades.php
 timeout /t 3 >nul
 goto loop

--- a/run_every_3s.sh
+++ b/run_every_3s.sh
@@ -3,5 +3,6 @@
 for i in {1..20}
 do
     php /home/admin/web/c-trade.ca/public_html/cron/cron_process_orders.php
+    php /home/admin/web/c-trade.ca/public_html/cron/update_open_trades.php
     sleep 3
 done

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -107,11 +107,13 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $stOpen->execute([$order['user_id'],$order['pair']]);
         $open = $stOpen->fetch(PDO::FETCH_ASSOC);
         if ($open) {
-            if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
-            $deposit = $open['price'] * $order['quantity'];
-            $profit  = ($open['price'] - $price) * $order['quantity'];
+            $qtyToClose = min($open['quantity'], $order['quantity']);
+            $order['quantity'] = $qtyToClose;
+            $total = $price * $qtyToClose;
+            $deposit = $open['price'] * $qtyToClose;
+            $profit  = ($open['price'] - $price) * $qtyToClose;
             $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$deposit + $profit, $order['user_id']]);
-            $remaining = $open['quantity'] - $order['quantity'];
+            $remaining = $open['quantity'] - $qtyToClose;
             if ($remaining > 0) {
                 $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);
                 $statusTx = 'En cours';
@@ -126,7 +128,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
                 addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
             }
             syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
-            return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
+            return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false,'quantity'=>$qtyToClose];
         }
 
         // No short to close - open a long position
@@ -145,7 +147,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         // track its profit/loss over time until it is closed.
         addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'En cours');
         syncTransaction($pdo,$order['user_id'],$opNum,$total,'En cours');
-        return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true];
+        return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true,'quantity'=>$order['quantity']];
     }
 
     // SELL orders either close a long position or open a new short
@@ -155,10 +157,12 @@ function executeTrade(PDO $pdo, array $order, float $price) {
 
     if ($open && $open['side'] === 'buy') {
         // Closing a long position
-        if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
-        $profit = ($price - $open['price']) * $order['quantity'];
+        $qtyToClose = min($open['quantity'], $order['quantity']);
+        $order['quantity'] = $qtyToClose;
+        $total = $price * $qtyToClose;
+        $profit = ($price - $open['price']) * $qtyToClose;
         $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);
-        $remaining = $open['quantity'] - $order['quantity'];
+        $remaining = $open['quantity'] - $qtyToClose;
         if ($remaining > 0) {
             $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);
             $statusTx = 'En cours';
@@ -173,7 +177,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
         }
         syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
-        return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
+        return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false,'quantity'=>$qtyToClose];
     }
 
     // No long position to close - open a short position
@@ -190,6 +194,6 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     $opNum = 'T'.$tradeId;
     addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours');
     syncTransaction($pdo,$order['user_id'],$opNum,$total,'En cours');
-    return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true];
+    return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true,'quantity'=>$order['quantity']];
 }
 ?>


### PR DESCRIPTION
## Summary
- Allow market orders to partially close positions instead of failing when requesting more than available
- Track executed quantities in market orders and push accurate trade updates
- Add cron job to update open trade profit/loss and notify clients; wire up JS handlers

## Testing
- `php -l php/market_order.php`
- `php -l utils/helpers.php`
- `php -l cron/update_open_trades.php`
- `bash -n run_every_3s.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890a66bdf3c8332aeeb7e76a6bec88f