### PR TITLE
Add market order tracking and manual close button

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -337,7 +337,7 @@ Mon compte </button>
 <i class="fas fa-history me-2"></i> Historique du trading
                     </div>
 <div class="card-body">
-<div id="cancelOrderAlert"></div>
+<div id="stopOrderAlert"></div>
 <div class="table-responsive" style="max-height: 250px; overflow-y: auto;">
 <table class="table table-hover" id="historiqueTrading">
 <thead>

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1353,7 +1353,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td>${trade.statut==='En cours' && trade.order_type==='market' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Fermé"><i class="fas fa-ban"></i></button>`) : '-'}</td>
+                        <td>${trade.statut==='En cours' && trade.order_type==='market' ? (trade.blocked ? '<i class="fas fa-lock text-muted" title="Bloqué"></i>' : `<button class="btn btn-sm btn-danger stop-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Stop"><i class="fas fa-stop"></i></button>`) : '-'}</td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);
@@ -1726,7 +1726,7 @@ function initializeUI() {
         $loginHistoryBody.html('<tr><td colspan="3" class="text-center">Aucune donnée disponible</td></tr>');
     }
 
-    $('#tradingHistory').on('click', '.cancel-order-btn', async function() {
+    $('#tradingHistory').on('click', '.stop-order-btn', async function() {
         const $btn = $(this);
         $btn.prop('disabled', true);
         const op = $btn.data('op');
@@ -1747,20 +1747,20 @@ function initializeUI() {
                             quantity: openTrade.quantity
                         })
                     });
-                    showBootstrapAlert('cancelOrderAlert', 'Position clôturée.', 'success');
+                    showBootstrapAlert('stopOrderAlert', 'Position clôturée.', 'success');
                 } else {
                     await apiFetch('php/cancel_order.php', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ user_id: userId, order_id: orderId })
                     });
-                    showBootstrapAlert('cancelOrderAlert', 'Ordre annulé.', 'success');
+                    showBootstrapAlert('stopOrderAlert', 'Ordre annulé.', 'success');
                 }
             } catch (e) {
-                showBootstrapAlert('cancelOrderAlert', e.message || 'Erreur lors de l\'annulation', 'danger');
+                showBootstrapAlert('stopOrderAlert', e.message || 'Erreur lors de l\'annulation', 'danger');
             }
         } else {
-            showBootstrapAlert('cancelOrderAlert', 'Cet ordre ne peut pas être annulé.', 'warning');
+            showBootstrapAlert('stopOrderAlert', 'Cet ordre ne peut pas être annulé.', 'warning');
         }
         $btn.prop('disabled', false);
     });

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -47,7 +47,7 @@ try{
             ->execute([$order['related_order_id']]);
     }
     $price = isset($order['target_price']) ? $order['target_price'] : 0;
-    addHistory($pdo,$userId,'T'.$orderId,$order['pair'],$order['side'],$order['quantity'],$price,'annule');
+    addHistory($pdo,$userId,'T'.$orderId,$order['pair'],$order['side'],$order['quantity'],$price,'annule',null,$order['type'] ?? null);
     $pdo->commit();
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('order_cancelled',['order_id'=>$orderId],$userId);

--- a/php/market_order.php
+++ b/php/market_order.php
@@ -48,7 +48,8 @@ try {
         'user_id' => $userId,
         'pair' => $pair,
         'side' => $side,
-        'quantity' => $quantity
+        'quantity' => $quantity,
+        'type' => 'market'
     ];
     $result = executeTrade($pdo, $order, $price);
     if (!$result['ok']) {

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -143,7 +143,7 @@ try {
 
     if($type==='market'){
         $pdo->beginTransaction();
-        $order=['id'=>0,'user_id'=>$userId,'pair'=>$pair,'side'=>$side,'quantity'=>$qty];
+        $order=['id'=>0,'user_id'=>$userId,'pair'=>$pair,'side'=>$side,'quantity'=>$qty,'type'=>'market'];
         $result = executeTrade($pdo,$order,$livePrice);
         if(!$result['ok']){ $pdo->rollBack(); http_response_code(400); echo json_encode(['status'=>'error','message'=>$result['msg']]); return; }
         $pdo->commit();
@@ -187,7 +187,7 @@ try {
     $stmt->execute([$userId,$pair,$type,$side,$qty,$limit,$stop,$trailPerc,$stopPercent,$stopTime,$trailPrice]);
     $id=$pdo->lastInsertId();
     $opNum = 'T'.$id;
-    addHistory($pdo,$userId,$opNum,$pair,$side,$qty,$limit ?? $livePrice,'En cours');
+    addHistory($pdo,$userId,$opNum,$pair,$side,$qty,$limit ?? $livePrice,'En cours',null,$type);
 
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('new_order', [

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -31,13 +31,17 @@ function getHistoricalPrice(string $pair, int $timestamp): float {
 }
 
 function addHistory(PDO $pdo, int $uid, string $opNum, string $pair, string $side,
-    float $qty, float $price, string $status, ?float $profit = null): void {
+    float $qty, float $price, string $status, ?float $profit = null, ?string $orderType = null): void {
     $typeTxt = $side === 'buy' ? 'Acheter' : 'Vendre';
     $typeClass = $side === 'buy' ? 'bg-success' : 'bg-danger';
     $statutClass = $status === 'complet' ? 'bg-success'
         : ($status === 'annule' ? 'bg-danger' : 'bg-warning');
     $profitClass = $profit === null ? '' : ($profit >= 0 ? 'text-success' : 'text-danger');
-    $details = json_encode(['order_id' => ltrim($opNum, 'T')]);
+    $det = ['order_id' => ltrim($opNum, 'T')];
+    if ($orderType !== null) {
+        $det['order_type'] = $orderType;
+    }
+    $details = json_encode($det);
     $stmt = $pdo->prepare('INSERT INTO tradingHistory '
         . '(user_id, operationNumber, temps, paireDevises, type, statutTypeClass,'
         . ' montant, prix, statut, statutClass, profitPerte, profitClass, details) '
@@ -99,6 +103,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     $st->execute([$order['user_id']]);
     $bal = (float)$st->fetchColumn();
     $total = $price * $order['quantity'];
+    $orderType = $order['type'] ?? 'market';
 
     // BUY orders either open a long position or close an existing short
     if ($order['side'] === 'buy') {
@@ -122,10 +127,10 @@ function executeTrade(PDO $pdo, array $order, float $price) {
                 $statusTx = 'complet';
             }
             $opNum = 'T'.$open['id'];
-            addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
+            addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'complet',$profit,$orderType);
             if (!empty($order['id'])) {
                 $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
-                addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
+                addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'buy',$order['quantity'],$price,'complet',$profit,$orderType);
             }
             syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
             return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false,'quantity'=>$qtyToClose];
@@ -140,12 +145,12 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $tradeId = $pdo->lastInsertId();
         if ($orderId !== null) {
             $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
-            addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'buy',$order['quantity'],$price,'complet');
+            addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'buy',$order['quantity'],$price,'complet',null,$orderType);
         }
         $opNum = 'T'.$tradeId;
         // Record this trade as open in the trading history so that the UI can
         // track its profit/loss over time until it is closed.
-        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'En cours');
+        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'En cours',null,$orderType);
         syncTransaction($pdo,$order['user_id'],$opNum,$total,'En cours');
         return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true,'quantity'=>$order['quantity']];
     }
@@ -171,10 +176,10 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             $statusTx = 'complet';
         }
         $opNum = 'T'.$open['id'];
-        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
+        addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit,$orderType);
         if (!empty($order['id'])) {
             $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$order['id']]);
-            addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
+            addHistory($pdo,$order['user_id'],'T'.$order['id'],$order['pair'],'sell',$order['quantity'],$price,'complet',$profit,$orderType);
         }
         syncTransaction($pdo,$order['user_id'],$opNum,$total,$statusTx);
         return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false,'quantity'=>$qtyToClose];
@@ -189,10 +194,10 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     $tradeId = $pdo->lastInsertId();
     if ($orderId !== null) {
         $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
-        addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'sell',$order['quantity'],$price,'complet');
+        addHistory($pdo,$order['user_id'],'T'.$orderId,$order['pair'],'sell',$order['quantity'],$price,'complet',null,$orderType);
     }
     $opNum = 'T'.$tradeId;
-    addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours');
+    addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours',null,$orderType);
     syncTransaction($pdo,$order['user_id'],$opNum,$total,'En cours');
     return ['ok'=>true,'balance'=>$bal-$total,'price'=>$price,'profit'=>0,'operation'=>$opNum,'opened'=>true,'quantity'=>$order['quantity']];
 }


### PR DESCRIPTION
## Summary
- Track order type in trading history and record when executing market orders
- Allow stopping open market trades from trading history with a new stop button

## Testing
- `php -l utils/helpers.php`
- `php -l php/market_order.php`
- `php -l php/place_order.php`
- `php -l php/cancel_order.php`
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_6890a99d91e08332bc6b4dfe4225cc43