### PR TITLE
Reindex arrays before executing admin queries

### DIFF
--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -66,7 +66,7 @@ if ((int)$admin['is_admin'] === 2) {
     if ($agentIds) {
         $placeholders = implode(',', array_fill(0, count($agentIds), '?'));
         $stmt = $pdo->prepare("SELECT id,email,is_admin,created_by FROM admins_agents WHERE id IN ($placeholders)");
-        $stmt->execute($agentIds);
+        $stmt->execute(array_values($agentIds));
         $result['agents'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
     } else {
         $result['agents'] = [];
@@ -92,7 +92,7 @@ $userParams = [];
 if ((int)$admin['is_admin'] !== 2) {
     $placeholders = implode(',', array_fill(0, count($descendantAdminIds), '?'));
     $userSql .= " WHERE linked_to_id IN ($placeholders)";
-    $userParams = $descendantAdminIds;
+    $userParams = array_values($descendantAdminIds);
 }
 if ($startDate) {
     $userSql .= (strpos($userSql, 'WHERE') === false ? ' WHERE' : ' AND') .
@@ -100,7 +100,7 @@ if ($startDate) {
     $userParams[] = $startDate;
 }
 $stmt = $pdo->prepare($userSql);
-$stmt->execute($userParams);
+$stmt->execute(array_values($userParams));
 $result['users'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $stmt = null;
@@ -112,7 +112,7 @@ if ((int)$admin['is_admin'] === 2) {
         . 'FROM kyc k JOIN personal_data p ON k.user_id=p.user_id '
         . "WHERE p.linked_to_id IN ($placeholders) AND k.status = \"pending\"";
     $stmt = $pdo->prepare($sql);
-    $stmt->execute($descendantAdminIds);
+    $stmt->execute(array_values($descendantAdminIds));
 }
 $result['kyc'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -131,7 +131,7 @@ if ($userIds) {
         $params[] = $startDate;
     }
     $stmt = $pdo->prepare($sql);
-    $stmt->execute($params);
+    $stmt->execute(array_values($params));
     foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
         $sumDeposits += (float)$row['amount'];
         $depositCount++;
@@ -167,7 +167,7 @@ if ((int)$admin['is_admin'] === 2) {
             ORDER BY n.id DESC
             LIMIT 10";
     $stmt = $pdo->prepare($sql);
-    $stmt->execute($userIds);
+    $stmt->execute(array_values($userIds));
     $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
     foreach ($notifications as &$n) {
         $n['time'] = formatTimeAgoFromDate($n['time']);


### PR DESCRIPTION
## Summary
- Reindex agent, user, KYC, deposit, and notification parameter arrays before executing queries
- Prevents `SQLSTATE[HY093]: Invalid parameter number` for normal admins

## Testing
- `php -l php/admin_getter.php`


------
https://chatgpt.com/codex/tasks/task_e_6890c71cbb7c8332ac34874be9663945