### PR TITLE
Fix undefined price polling

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -377,9 +377,9 @@ function stopAutoRefresh() {
     }
 }
 
-function startPricePolling() {
+function startPricePolling(fetchPriceFn) {
     if (priceInterval) return;
-    priceInterval = setInterval(() => fetchPrice(selectedPairVal), 1000);
+    priceInterval = setInterval(() => fetchPriceFn(selectedPairVal), 1000);
 }
 
 function stopPricePolling() {
@@ -1731,7 +1731,7 @@ function initializeUI() {
     });
 
     fetchPrice(selectedPairVal);
-    startPricePolling();
+    startPricePolling(fetchPrice);
     renderTradingHistory();
 
     const $loginHistoryBody = $('#loginHistoryBody');


### PR DESCRIPTION
## Summary
- decouple price polling from global fetchPrice by passing it as a parameter
- call startPricePolling with local fetchPrice implementation

## Testing
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_6890d0b3020083329b29f6edc1944a33