### PR TITLE
fix: guard against array values when saving user data

### DIFF
--- a/php/setter.php
+++ b/php/setter.php
@@ -23,6 +23,10 @@ try {
     if (isset($data['personalData'])) {
         $personal = $data['personalData'];
         unset($personal['linked_to_id']);
+
+        // Exclude any nested arrays/objects to avoid "Array to string conversion"
+        // notices when binding parameters. Only scalar values are persisted.
+        $personal = array_filter($personal, fn($v) => !is_array($v));
         $personal['user_id'] = $userId;
 
         $cols = array_keys($personal);


### PR DESCRIPTION
## Summary
- ignore non-scalar fields in `personalData` to avoid array-to-string warnings on save

## Testing
- `php -l php/setter.php`


------
https://chatgpt.com/codex/tasks/task_e_6890d20bdf748332890b22cf16401524