### PR TITLE
Add structured order types and profit tracking

### DIFF
--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -36,8 +36,6 @@ try{
     }
     $price = isset($order['target_price']) ? $order['target_price'] : 0;
     addHistory($pdo,$userId,'T'.$orderId,$order['pair'],$order['side'],$order['quantity'],$price,'annule');
-    $pdo->prepare('UPDATE transactions SET status=?, statusClass=? WHERE operationNumber=? AND user_id=?')
-        ->execute(['annule','bg-danger','T'.$orderId,$userId]);
     $pdo->commit();
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('order_cancelled',['order_id'=>$orderId],$userId);

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -181,13 +181,67 @@ try {
         return;
     }
 
-    // For pending orders just record
-    $stmt=$pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,NULL)');
-    $trailPrice = $livePrice>0 ? $livePrice : null;
-    $stmt->execute([$userId,$pair,$type,$side,$qty,$limit,$stop,$trailPerc,$stopPercent,$stopTime,$trailPrice]);
-    $id=$pdo->lastInsertId();
+    // Handle other order types
+    if ($type === 'limit') {
+        // [LIMIT ORDER LOGIC]
+        $amount = $limit * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'limit',$side,$qty,$amount,$limit,null,null,null,null,null,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'stop') {
+        // [STOP ORDER LOGIC]
+        $amount = $stop * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'stop',$side,$qty,$amount,null,$stop,null,null,null,null,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'stop_limit') {
+        // [STOP-LIMIT ORDER LOGIC]
+        $amount = $limit * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'stop_limit',$side,$qty,$amount,$limit,$stop,null,null,null,null,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'trailing_stop') {
+        // [TRAILING STOP ORDER LOGIC]
+        $trailPrice = $livePrice > 0 ? $livePrice : null;
+        $amount = ($trailPrice ?? 0) * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'trailing_stop',$side,$qty,$amount,null,null,$trailPerc,null,null,$trailPrice,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'percentage_stop') {
+        // [PERCENTAGE STOP ORDER LOGIC]
+        $trailPrice = $livePrice > 0 ? $livePrice : null;
+        $amount = ($trailPrice ?? 0) * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'percentage_stop',$side,$qty,$amount,null,null,null,$stopPercent,null,$trailPrice,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'time_stop') {
+        // [TIME STOP ORDER LOGIC]
+        $trailPrice = $livePrice > 0 ? $livePrice : null;
+        $amount = ($trailPrice ?? 0) * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'time_stop',$side,$qty,$amount,null,null,null,null,$stopTime,$trailPrice,null]);
+        $id = $pdo->lastInsertId();
+    } else if ($type === 'oco') {
+        // [OCO ORDER LOGIC]
+        $amount = $limit * $qty;
+        $stmt = $pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stmt->execute([$userId,$pair,'limit',$side,$qty,$amount,$limit,null,null,null,null,null,null]);
+        $id = $pdo->lastInsertId();
+        // create second order for stop limit part using provided stop_limit_price
+        $amount2 = $stopLimit * $qty;
+        $stopLimitOrder=$pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,amount,target_price,stop_price,trailing_percentage,stop_percentage,stop_time,trail_price,related_order_id,profit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0)');
+        $stopLimitOrder->execute([$userId,$pair,'stop_limit',$side,$qty,$amount2,$stopLimit,$stop,null,null,null,null,$id]);
+        $secondId=$pdo->lastInsertId();
+        $pdo->prepare('UPDATE orders SET related_order_id=? WHERE id=?')->execute([$secondId,$id]);
+    } else {
+        http_response_code(400);
+        echo json_encode(['status'=>'error','message'=>'Unsupported order type']);
+        return;
+    }
+
     $opNum = 'T'.$id;
-    addHistory($pdo,$userId,$opNum,$pair,$side,$qty,$limit ?? $livePrice,'En cours');
+    $priceRef = $limit ?? $stop ?? $livePrice;
+    addHistory($pdo,$userId,$opNum,$pair,$side,$qty,$priceRef,'En cours');
 
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('new_order', [
@@ -202,14 +256,6 @@ try {
         'stop_percentage' => $stopPercent,
         'stop_time' => $stopTime
     ], $userId);
-
-    if($type==='oco'){
-        // create second order for stop limit part using provided stop_limit_price
-        $stopLimitOrder=$pdo->prepare('INSERT INTO orders (user_id,pair,type,side,quantity,target_price,stop_price,related_order_id) VALUES (?,?,?,?,?,?,?,?)');
-        $stopLimitOrder->execute([$userId,$pair,'stop_limit',$side,$qty,$stopLimit,$stop,$id]);
-        $secondId=$pdo->lastInsertId();
-        $pdo->prepare('UPDATE orders SET related_order_id=? WHERE id=?')->execute([$secondId,$id]);
-    }
 
     [$base] = explode('/', strtoupper($pair));
     $typeLabel = str_replace('_', ' ', $type);

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -181,6 +181,7 @@ CREATE TABLE orders (
     type ENUM('market','limit','stop','stop_limit','trailing_stop','percentage_stop','time_stop','oco'),
     side ENUM('buy','sell'),
     quantity DECIMAL(20,10),
+    amount DECIMAL(20,10),
     target_price DECIMAL(20,10),
     stop_price DECIMAL(20,10),
     trailing_percentage DECIMAL(10,4),
@@ -191,6 +192,7 @@ CREATE TABLE orders (
     status ENUM('open','triggered','filled','cancelled') DEFAULT 'open',
     price_at_execution DECIMAL(20,10),
     executed_at DATETIME,
+    profit DECIMAL(20,10),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE,
     FOREIGN KEY (related_order_id) REFERENCES orders(id) ON DELETE SET NULL

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -100,24 +100,6 @@ BEGIN
   END IF;
 END//
 
-CREATE TRIGGER trg_orders_after_insert
-AFTER INSERT ON orders
-FOR EACH ROW
-BEGIN
-  DECLARE op VARCHAR(50);
-  DECLARE orderPrice DECIMAL(20,10);
-  DECLARE adminId BIGINT;
-  SET op = CONCAT('T', NEW.id);
-  SELECT linked_to_id INTO adminId FROM personal_data WHERE user_id = NEW.user_id;
-  SET orderPrice = COALESCE(NEW.target_price, NEW.stop_price, NEW.trail_price, 0);
-  INSERT INTO transactions
-    (user_id, admin_id, operationNumber, type, amount, date, status, statusClass)
-  VALUES
-    (NEW.user_id, adminId, op, 'Trading',
-     orderPrice * NEW.quantity,
-     DATE_FORMAT(NOW(), '%Y/%m/%d'), 'En cours', 'bg-warning');
-END//
-
 CREATE TRIGGER trg_trades_after_insert
 AFTER INSERT ON trades
 FOR EACH ROW

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -63,9 +63,10 @@ function addHistory(PDO $pdo, int $uid, string $opNum, string $pair, string $sid
 }
 
 function executeTrade(PDO $pdo, array $order, float $price) {
-    if (!empty($order['id'])) {
+    $orderId = $order['id'] ?? null;
+    if ($orderId) {
         $check = $pdo->prepare('SELECT 1 FROM trades WHERE order_id = ?');
-        $check->execute([$order['id']]);
+        $check->execute([$orderId]);
         if ($check->fetchColumn()) {
             return ['ok' => false, 'msg' => 'Order already filled'];
         }
@@ -93,6 +94,11 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             } else {
                 $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')->execute([$price,$profit,$open['id']]);
             }
+            if ($orderId) {
+                $executedAmount = $price * $order['quantity'];
+                $pdo->prepare('UPDATE orders SET status="filled", price_at_execution=?, executed_at=NOW(), amount=?, profit=? WHERE id=?')
+                    ->execute([$price, $executedAmount, $profit, $orderId]);
+            }
             $opNum = 'T'.$open['id'];
             addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'buy',$order['quantity'],$price,'complet',$profit);
             return ['ok'=>true,'balance'=>$bal + $deposit + $profit,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
@@ -101,12 +107,13 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         // No short to close - open a long position
         if ($bal < $total) return ['ok' => false, 'msg' => 'Solde insuffisant'];
         $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total, $order['user_id']]);
-        $orderId = empty($order['id']) ? null : $order['id'];
         $stmt = $pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss,status) VALUES (?,?,?,?,?,?,?,0,0,"open")');
         $stmt->execute([$order['user_id'],$orderId,$order['pair'],'buy',$order['quantity'],$price,$total]);
         $tradeId = $pdo->lastInsertId();
-        if ($orderId !== null) {
-            $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
+        if ($orderId) {
+            $executedAmount = $price * $order['quantity'];
+            $pdo->prepare('UPDATE orders SET status="filled", price_at_execution=?, executed_at=NOW(), amount=?, profit=? WHERE id=?')
+                ->execute([$price, $executedAmount, 0, $orderId]);
         }
         $opNum = 'T'.($order['id'] ?: $tradeId);
         // Record this trade as open in the trading history so that the UI can
@@ -131,6 +138,11 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         } else {
             $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')->execute([$price,$profit,$open['id']]);
         }
+        if ($orderId) {
+            $executedAmount = $price * $order['quantity'];
+            $pdo->prepare('UPDATE orders SET status="filled", price_at_execution=?, executed_at=NOW(), amount=?, profit=? WHERE id=?')
+                ->execute([$price, $executedAmount, $profit, $orderId]);
+        }
         $opNum = 'T'.$open['id'];
         addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'complet',$profit);
         return ['ok'=>true,'balance'=>$bal+$total,'price'=>$price,'profit'=>$profit,'operation'=>$opNum,'opened'=>false];
@@ -139,12 +151,13 @@ function executeTrade(PDO $pdo, array $order, float $price) {
     // No long position to close - open a short position
     if ($bal < $total) return ['ok' => false, 'msg' => 'Solde insuffisant'];
     $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$total, $order['user_id']]);
-    $orderId = empty($order['id']) ? null : $order['id'];
     $stmt = $pdo->prepare('INSERT INTO trades (user_id,order_id,pair,side,quantity,price,total_value,fee,profit_loss,status) VALUES (?,?,?,?,?,?,?,0,0,"open")');
     $stmt->execute([$order['user_id'],$orderId,$order['pair'],'sell',$order['quantity'],$price,$total]);
     $tradeId = $pdo->lastInsertId();
-    if ($orderId !== null) {
-        $pdo->prepare('UPDATE orders SET status="filled",price_at_execution=?,executed_at=NOW() WHERE id=?')->execute([$price,$orderId]);
+    if ($orderId) {
+        $executedAmount = $price * $order['quantity'];
+        $pdo->prepare('UPDATE orders SET status="filled", price_at_execution=?, executed_at=NOW(), amount=?, profit=? WHERE id=?')
+            ->execute([$price, $executedAmount, 0, $orderId]);
     }
     $opNum = 'T'.($order['id'] ?: $tradeId);
     addHistory($pdo,$order['user_id'],$opNum,$order['pair'],'sell',$order['quantity'],$price,'En cours');


### PR DESCRIPTION
## Summary
- Implement conditional blocks for limit, stop, stop-limit, trailing, percentage, time and OCO orders alongside existing market logic
- Track order amounts and realized profit in the orders table and during trade execution
- Remove upfront transaction creation and streamline order cancellation flow

## Testing
- `php -l coin/php/cancel_order.php`
- `php -l coin/utils/helpers.php`
- `php -l coin/php/place_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6890dc5cddb8833282007a9193b826ab