### PR TITLE
Avoid inserting bogus order_id in market trades

### DIFF
--- a/php/market_order.php
+++ b/php/market_order.php
@@ -44,7 +44,7 @@ try {
 
     $pdo->beginTransaction();
     $order = [
-        'id' => 0,
+        'id' => null,
         'user_id' => $userId,
         'pair' => $pair,
         'side' => $side,

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -143,7 +143,7 @@ try {
 
     if($type==='market'){
         $pdo->beginTransaction();
-        $order=['id'=>0,'user_id'=>$userId,'pair'=>$pair,'side'=>$side,'quantity'=>$qty];
+        $order=['id'=>null,'user_id'=>$userId,'pair'=>$pair,'side'=>$side,'quantity'=>$qty];
         $result = executeTrade($pdo,$order,$livePrice);
         if(!$result['ok']){ $pdo->rollBack(); http_response_code(400); echo json_encode(['status'=>'error','message'=>$result['msg']]); return; }
         $pdo->commit();


### PR DESCRIPTION
## Summary
- Set order id to null when executing market trades to avoid foreign key violations

## Testing
- `php -l php/market_order.php`
- `php -l php/place_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6890e3b59b008332b570b07d5ceceb62