### PR TITLE
Fix trade price recalculation when editing profit

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -867,6 +867,7 @@
                     <input type="hidden" id="editTxId">
                     <input type="hidden" id="editTxOldProfit">
                     <input type="hidden" id="editTxOldPrice">
+                    <input type="hidden" id="editTxQuantity">
                     <div class="mb-3">
                         <label for="editTxProfit" class="form-label">Profit/Perte</label>
                         <input type="number" step="0.01" class="form-control" id="editTxProfit" required>
@@ -1910,6 +1911,7 @@
                     document.getElementById('editTxPrice').value = trade.prix ?? '';
                     document.getElementById('editTxOldProfit').value = trade.profitPerte ?? '';
                     document.getElementById('editTxOldPrice').value = trade.prix ?? '';
+                    document.getElementById('editTxQuantity').value = trade.montant ?? 1;
                     if (profitLabel) profitLabel.textContent = 'Profit/Perte';
                     priceGroup.style.display = '';
                 } catch (err) {
@@ -1921,6 +1923,7 @@
                 profitInput.classList.remove('text-success','text-danger');
                 document.getElementById('editTxOldProfit').value = tx.amount ?? '';
                 document.getElementById('editTxOldPrice').value = '';
+                document.getElementById('editTxQuantity').value = 1;
                 if (profitLabel) profitLabel.textContent = 'Montant';
                 priceGroup.style.display = 'none';
             }
@@ -1974,7 +1977,8 @@
             if (CURRENT_TX_TYPE === 'Trading') {
                 const oldProfit = parseFloat(document.getElementById('editTxOldProfit').value) || 0;
                 const oldPrice = parseFloat(document.getElementById('editTxOldPrice').value) || 0;
-                const newPrice = oldPrice + (val - oldProfit);
+                const qty = parseFloat(document.getElementById('editTxQuantity').value) || 1;
+                const newPrice = oldPrice + (val - oldProfit) / qty;
                 document.getElementById('editTxPrice').value = newPrice.toFixed(2);
             }
         });

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -306,7 +306,7 @@ try {
         }
         $pdo->beginTransaction();
         try {
-            $stmt = $pdo->prepare('SELECT th.user_id, th.prix, th.profitPerte, p.linked_to_id FROM tradingHistory th JOIN personal_data p ON p.user_id = th.user_id WHERE th.operationNumber = ? FOR UPDATE');
+            $stmt = $pdo->prepare('SELECT th.user_id, th.prix, th.montant, th.profitPerte, p.linked_to_id FROM tradingHistory th JOIN personal_data p ON p.user_id = th.user_id WHERE th.operationNumber = ? FOR UPDATE');
             $stmt->execute([$op]);
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
             if (!$row) {
@@ -322,8 +322,9 @@ try {
             }
             $oldPrice = (float)$row['prix'];
             $oldProfit = (float)$row['profitPerte'];
+            $qty = (float)$row['montant'];
             $diff = $profit - $oldProfit;
-            $newPrice = $oldPrice + $diff;
+            $newPrice = $qty != 0 ? $oldPrice + ($diff / $qty) : $oldPrice;
             $profitClass = $profit >= 0 ? 'text-success' : 'text-danger';
             $pdo->prepare('UPDATE tradingHistory SET profitPerte = ?, prix = ?, profitClass = ? WHERE operationNumber = ?')->execute([$profit, $newPrice, $profitClass, $op]);
             $pdo->prepare('UPDATE transactions SET amount = ? WHERE operationNumber = ?')->execute([$profit, $op]);

--- a/php/admin_trade_getter.php
+++ b/php/admin_trade_getter.php
@@ -34,12 +34,12 @@ try {
     $isAdmin = (int)$stmt->fetchColumn();
 
     if ($isAdmin === 2) {
-        $stmt = $pdo->prepare('SELECT profitPerte, prix FROM tradingHistory WHERE operationNumber = ?');
+        $stmt = $pdo->prepare('SELECT profitPerte, prix, montant FROM tradingHistory WHERE operationNumber = ?');
         $stmt->execute([$op]);
     } else {
         $linkedIds = getDescendantAdminIds($pdo, $adminId);
         $placeholders = implode(',', array_fill(0, count($linkedIds), '?'));
-        $sql = 'SELECT th.profitPerte, th.prix FROM tradingHistory th '
+        $sql = 'SELECT th.profitPerte, th.prix, th.montant FROM tradingHistory th '
             . 'JOIN personal_data p ON p.user_id = th.user_id '
             . 'WHERE th.operationNumber = ? AND p.linked_to_id IN (' . $placeholders . ')';
         $params = array_merge([$op], $linkedIds);


### PR DESCRIPTION
## Summary
- send trade quantity in admin trade getter
- compute new trade price using quantity when editing profit
- store quantity in edit modal and adjust displayed price

## Testing
- `php -l php/admin_trade_getter.php`
- `php -l php/admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_68918a87668483328a844aa3490ff66e