### PR TITLE
Add transaction IDs to deposit and withdrawal history

### DIFF
--- a/dashbord_user.html
+++ b/dashbord_user.html
@@ -643,6 +643,7 @@ Mon compte </button>
 <thead>
 <tr>
     <th>Date</th>
+    <th>ID transaction</th>
     <th>Quantité</th>
     <th>Méthode</th>
     <th>Statut</th>
@@ -845,6 +846,7 @@ Mon compte </button>
 <thead>
 <tr>
 <th>Date</th>
+<th>ID transaction</th>
 <th>Quantité</th>
 <th>Méthode</th>
 <th>Statut</th>

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1310,13 +1310,14 @@ function initializeUI() {
                 $tbodyDeposits.append(`
                     <tr>
                         <td>${escapeHtml(d.date)}</td>
+                        <td>${escapeHtml(d.operationNumber)}</td>
                         <td>${formatDollar(d.amount)}</td>
                         <td>${escapeHtml(d.method)}</td>
                         <td><span class="badge ${escapeHtml(d.statusClass)}">${escapeHtml(d.status)}</span></td>
                     </tr>`);
             });
         } else {
-            $tbodyDeposits.html('<tr><td colspan="4" class="text-center">Aucune donnée disponible</td></tr>');
+            $tbodyDeposits.html('<tr><td colspan="5" class="text-center">Aucune donnée disponible</td></tr>');
         }
     }
 
@@ -1329,13 +1330,14 @@ function initializeUI() {
                 $tbodyRetraits.append(`
                     <tr>
                         <td>${escapeHtml(r.date)}</td>
+                        <td>${escapeHtml(r.operationNumber)}</td>
                         <td>${formatDollar(r.amount)}</td>
                         <td>${escapeHtml(r.method)}</td>
                         <td><span class="badge ${escapeHtml(r.statusClass)}">${escapeHtml(r.status)}</span></td>
                     </tr>`);
             });
         } else {
-            $tbodyRetraits.html('<tr><td colspan="4" class="text-center">Aucune donnée disponible</td></tr>');
+            $tbodyRetraits.html('<tr><td colspan="5" class="text-center">Aucune donnée disponible</td></tr>');
         }
     }
 


### PR DESCRIPTION
## Summary
- show transaction ID column in deposit and withdrawal history tables
- include operation numbers when rendering histories and adjust empty states

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f1c796a483328da2758d03ce08e5