### PR TITLE
Fix admin dashboard notifications layout and HTML structure

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -228,9 +228,9 @@
                             </div>
                         </div>
                         
-                        <div class="row">
-                            <div class="col-md-8">
-                                <div class="card recent-activity-card">
+                        <div class="row align-items-stretch">
+                            <div class="col-md-8 mb-3 d-flex">
+                                <div class="card recent-activity-card w-100 h-100">
                                     <div class="card-header">
                                         <h5 class="mb-0">Activité Récente</h5>
                                     </div>
@@ -239,24 +239,22 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <div class="card">
+                            <div class="col-md-4 mb-3 d-flex">
+                                <div class="card w-100 h-100 d-flex flex-column">
                                     <div class="card-header">
                                         <h5 class="mb-0">Notifications</h5>
                                     </div>
-                                    <div class="card-body">
-                                        <textarea id="customNotification" class="form-control mb-3" rows="3" placeholder="Écrire une notification..."></textarea>
-                                        <button class="btn btn-primary mb-3" id="sendCustomNotification">Envoyer</button>
-                                        <div class="d-grid gap-2">
-                                            <button class="btn btn-outline-primary" id="notifyUpdateBtn">Mise à jour du système</button>
+                                    <div class="card-body d-flex flex-column">
+                                        <textarea id="customNotification" class="form-control mb-3 flex-grow-1" rows="3" placeholder="Écrire une notification..."></textarea>
+                                        <button class="btn btn-primary mb-3 d-flex align-items-center" id="sendCustomNotification"><i class="bi bi-send me-2"></i>Envoyer</button>
+                                        <div class="d-grid gap-2 mt-auto">
+                                            <button class="btn btn-outline-primary d-flex align-items-center justify-content-center" id="notifyUpdateBtn"><i class="bi bi-arrow-repeat me-2"></i>Mise à jour du système</button>
                                             <input type="date" class="form-control" id="updateDate" style="display:none;">
-                                            <button class="btn btn-outline-primary" id="notifyKycBtn">Vérification KYC requise</button>
-                                            <button class="btn btn-outline-primary" id="notifyMaintenanceBtn">Problème de paiement / Maintenance</button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                                            <button class="btn btn-outline-primary d-flex align-items-center justify-content-center" id="notifyKycBtn"><i class="bi bi-person-badge me-2"></i>Vérification KYC requise</button>
+                                            <button class="btn btn-outline-primary d-flex align-items-center justify-content-center" id="notifyMaintenanceBtn"><i class="bi bi-tools me-2"></i>Problème de paiement / Maintenance</button>
+                      </div>
+                  </div>
+              </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Make recent activity and notifications cards share equal height
- Add icons and improved layout for notification actions
- Remove stray closing tags that broke transactions and other sections

## Testing
- `npx -y htmlhint dashboard_admin.html`


------
https://chatgpt.com/codex/tasks/task_e_689202635fd88332b7c2262783c88709