### PR TITLE
feat: allow blocking trade transactions

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -1974,6 +1974,9 @@
                     const hideAccept = normalizedStatus === 'complet';
                     const acceptBtn = hideAccept ? ''
                         : `<button class="btn btn-sm btn-outline-success tx-accept" title="Complete"><i class="fas fa-check"></i></button>`;
+                    const blockBtn = t.type === 'Trading'
+                        ? `<button class="btn btn-sm btn-outline-warning me-1 tx-block" data-blocked="${t.blocked ? 1 : 0}" title="${t.blocked ? 'Release' : 'Block'}"><i class="fas ${t.blocked ? 'fa-unlock' : 'fa-ban'}"></i></button>`
+                        : '';
                     const row = `<tr data-id="${escapeHtml(t.operationNumber)}">`
                     + `<td class="text-muted fw-bold">${escapeHtml(t.operationNumber)}</td>`
                     + `<td>${escapeHtml(t.user_id)}</td>`
@@ -1982,6 +1985,7 @@
                     + `<td><span class="badge ${escapeHtml(t.statusClass || 'bg-secondary')}">${escapeHtml(t.status || '')}</span></td>`
                     + `<td>${escapeHtml(t.date || '')}</td>`
                     + `<td class="text-nowrap">`
+                    + blockBtn
                     + `<button class="btn btn-sm btn-outline-primary me-1 tx-edit" title="Edit"><i class="fas fa-edit"></i></button>`
                     + `<button class="btn btn-sm btn-outline-danger me-1 tx-reject" title="Reject"><i class="fas fa-times"></i></button>`
                     + `<button class="btn btn-sm btn-outline-secondary me-1 tx-remove" title="Remove"><i class="fas fa-trash-alt"></i></button>`
@@ -2099,6 +2103,15 @@
             loadTransactions();
         }
 
+        async function toggleTransactionBlock(id, block) {
+            await fetchWithAuth('php/admin_setter.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'block_transaction', id: id, block: block })
+            });
+            loadTransactions();
+        }
+
         async function openEditTransaction(tx) {
             const id = tx.operationNumber;
             CURRENT_TX_TYPE = tx.type || 'Autre';
@@ -2152,6 +2165,10 @@
                     if (confirm('Supprimer cette transaction ?')) {
                         updateTransaction(id, '', '', true);
                     }
+                } else if (e.target.closest('.tx-block')) {
+                    const btn = e.target.closest('.tx-block');
+                    const current = btn.getAttribute('data-blocked') === '1';
+                    toggleTransactionBlock(id, current ? 0 : 1);
                 }
             });
         }

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -480,6 +480,16 @@ try {
                 throw $e;
             }
         }
+    } elseif ($action === 'block_transaction') {
+        if ($isAdmin !== 2) { $forbidden(); }
+        $op = isset($data['id']) ? trim($data['id']) : '';
+        $block = isset($data['block']) ? (int)$data['block'] : 0;
+        if ($op === '') {
+            throw new Exception('Missing id');
+        }
+        $stmt = $pdo->prepare('UPDATE transactions SET blocked = ? WHERE operationNumber = ? AND type = "Trading"');
+        $stmt->execute([$block, $op]);
+        echo json_encode(['status' => 'ok']);
     } elseif ($action === 'broadcast_update') {
         if ($isAdmin !== 2) { $forbidden(); }
         $date = $data['date'] ?? '';

--- a/php/admin_transactions_getter.php
+++ b/php/admin_transactions_getter.php
@@ -71,7 +71,7 @@ $total = (int)$countStmt->fetchColumn();
     // MySQL doesn't allow binding parameters for LIMIT/OFFSET reliably when
     // using emulated prepares. Since the values are cast to integers above
     // it is safe to directly inject them into the SQL string.
-    $sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass
+    $sql = "SELECT t.operationNumber, t.user_id, t.type, t.amount, t.status, t.date, t.statusClass, t.blocked
         $baseSql
         ORDER BY STR_TO_DATE(t.date, '%Y/%m/%d') DESC
         LIMIT $pageSize OFFSET $offset";

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -29,6 +29,14 @@ try{
         echo json_encode(['status'=>'error','message'=>'Order not cancellable']);
         exit;
     }
+    $bstmt=$pdo->prepare('SELECT blocked FROM transactions WHERE operationNumber=?');
+    $bstmt->execute(['T'.$orderId]);
+    if((int)$bstmt->fetchColumn()===1){
+        $pdo->rollBack();
+        http_response_code(403);
+        echo json_encode(['status'=>'error','message'=>'Order blocked']);
+        exit;
+    }
     $pdo->prepare('UPDATE orders SET status="cancelled" WHERE id=?')->execute([$orderId]);
     if (!empty($order['related_order_id'])) {
         $pdo->prepare("UPDATE orders SET status='cancelled' WHERE id=? AND status IN ('open','triggered')")

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -52,6 +52,7 @@ CREATE TABLE transactions (
     date TEXT,
     status TEXT,
     statusClass TEXT,
+    blocked TINYINT(1) DEFAULT 0,
     UNIQUE(operationNumber),
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id)
         ON DELETE CASCADE ON UPDATE CASCADE,


### PR DESCRIPTION
## Summary
- add `blocked` column to transactions table
- allow super admin to toggle block on trading transactions
- prevent cancelling orders when related trade is blocked
- show block/unblock icon for trade transactions in admin dashboard

## Testing
- `php -l php/admin_transactions_getter.php`
- `php -l php/admin_setter.php`
- `php -l php/cancel_order.php`
- `npx --yes htmlhint dashboard_admin.html`

------
https://chatgpt.com/codex/tasks/task_e_6897182458688332b6ea5846e8405d62