### PR TITLE
Record pending trades in transactions

### DIFF
--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -44,6 +44,8 @@ try{
     }
     $price = isset($order['target_price']) ? $order['target_price'] : 0;
     addHistory($pdo,$userId,'T'.$orderId,$order['pair'],$order['side'],$order['quantity'],$price,'annule');
+    $pdo->prepare('UPDATE transactions SET status = ?, statusClass = ? WHERE operationNumber = ?')
+        ->execute(['annule', 'bg-danger', 'T'.$orderId]);
     $pdo->commit();
     require_once __DIR__.'/../utils/poll.php';
     pushEvent('order_cancelled',['order_id'=>$orderId],$userId);

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -241,6 +241,22 @@ try {
 
     $opNum = 'T'.$id;
     $priceRef = $limit ?? $stop ?? $livePrice;
+    // Record this pending order in transactions so it shows in history
+    $adminStmt = $pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id = ?');
+    $adminStmt->execute([$userId]);
+    $adminId = $adminStmt->fetchColumn();
+    $tStmt = $pdo->prepare('INSERT INTO transactions (user_id, admin_id, operationNumber, type, amount, date, status, statusClass) VALUES (?,?,?,?,?,?,?,?)');
+    $tStmt->execute([
+        $userId,
+        $adminId,
+        $opNum,
+        'Trading',
+        $amount,
+        date('Y/m/d'),
+        'En cours',
+        'bg-warning'
+    ]);
+
     addHistory($pdo,$userId,$opNum,$pair,$side,$qty,$priceRef,'En cours');
 
     require_once __DIR__.'/../utils/poll.php';


### PR DESCRIPTION
## Summary
- Log pending trade orders into the transactions table so they appear in user history
- Update transaction status when a pending order is cancelled

## Testing
- `php -l php/place_order.php`
- `php -l php/cancel_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6897271cfae08332bcadb105b16a949f