### PR TITLE
Allow agents to toggle order blocking and show blocked state to users

### DIFF
--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -2104,12 +2104,11 @@
         }
 
         async function toggleTransactionBlock(id, block) {
-            await fetchWithAuth('php/admin_setter.php', {
+            return fetchWithAuth('php/admin_setter.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'block_transaction', id: id, block: block })
             });
-            loadTransactions();
         }
 
         async function openEditTransaction(tx) {
@@ -2168,7 +2167,14 @@
                 } else if (e.target.closest('.tx-block')) {
                     const btn = e.target.closest('.tx-block');
                     const current = btn.getAttribute('data-blocked') === '1';
-                    toggleTransactionBlock(id, current ? 0 : 1);
+                    const newVal = current ? 0 : 1;
+                    toggleTransactionBlock(id, newVal).then(() => {
+                        btn.setAttribute('data-blocked', String(newVal));
+                        btn.title = newVal ? 'Release' : 'Block';
+                        const icon = btn.querySelector('i');
+                        icon.classList.toggle('fa-ban', newVal === 0);
+                        icon.classList.toggle('fa-unlock', newVal === 1);
+                    });
                 }
             });
         }

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1388,7 +1388,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td>${trade.statut==='En cours'?`<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`:'-'}</td>
+                        <td>${trade.statut==='En cours' && !trade.blocked ?`<button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button>`:'-'}</td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -481,7 +481,7 @@ try {
             }
         }
     } elseif ($action === 'block_transaction') {
-        if ($isAdmin !== 2) { $forbidden(); }
+        if ($isAdmin < 1) { $forbidden(); }
         $op = isset($data['id']) ? trim($data['id']) : '';
         $block = isset($data['block']) ? (int)$data['block'] : 0;
         if ($op === '') {

--- a/php/getter.php
+++ b/php/getter.php
@@ -107,7 +107,7 @@ $data = [
         }
         unset($r['details']);
         return $r;
-    }, fetchAll($pdo, 'SELECT operationNumber,temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass,details FROM tradingHistory WHERE user_id = ? ORDER BY id DESC', [$userId])),
+    }, fetchAll($pdo, 'SELECT th.operationNumber,th.temps,th.paireDevises,th.type,th.statutTypeClass,th.montant,th.prix,th.statut,th.statutClass,th.profitPerte,th.profitClass,th.details,t.blocked FROM tradingHistory th LEFT JOIN transactions t ON t.operationNumber = th.operationNumber WHERE th.user_id = ? ORDER BY th.id DESC', [$userId])),
     'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 100', [$userId]),
     'bankWithdrawInfo' => $bankWithdraw,
     'cryptoDepositAddresses' => fetchAll($pdo, 'SELECT id,crypto_name,wallet_info FROM deposit_crypto_address WHERE user_id = ?', [$userId]),


### PR DESCRIPTION
## Summary
- Join trading history with transactions so admin/user interfaces know if an order is blocked
- Hide cancel button for trades whose transactions are blocked
- Permit both admins and agents to block or release trading transactions and reflect the state on the block button

## Testing
- `php -l php/getter.php`
- `php -l php/admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_689730c599ec83328fcd6dade80f3ef7