### PR TITLE
Ensure cancel button remains visible for blocked orders

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1388,7 +1388,7 @@ function initializeUI() {
                         <td>${formatDollar(trade.prix)}</td>
                         <td><span class="badge ${escapeHtml(trade.statutClass)}">${escapeHtml(trade.statut)}</span></td>
                         <td class="${escapeHtml(profitCls)}" data-profit>${profitText}</td>
-                        <td><button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler" ${trade.blocked ? 'disabled' : ''}><i class="fas fa-ban"></i></button></td>
+                        <td><button class="btn btn-sm btn-danger cancel-order-btn" data-op="${escapeHtml(trade.operationNumber)}" title="Annuler"><i class="fas fa-ban"></i></button></td>
                     </tr>`);
             });
             if (openTrades.length) updateOpenTradeProfits(openTrades);


### PR DESCRIPTION
## Summary
- Always render the cancel-order button so it's visible even when a transaction is blocked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689744440a208332a6a3b4924c66fd3c