### PR TITLE
Block server-side closing of restricted trades

### DIFF
--- a/php/market_order.php
+++ b/php/market_order.php
@@ -53,7 +53,7 @@ try {
     $result = executeTrade($pdo, $order, $price);
     if (!$result['ok']) {
         $pdo->rollBack();
-        http_response_code(400);
+        http_response_code($result['msg'] === 'Order blocked' ? 403 : 400);
         echo json_encode(['status' => 'error', 'message' => $result['msg']]);
         return;
     }

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -89,6 +89,11 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $stOpen->execute([$order['user_id'],$order['pair']]);
         $open = $stOpen->fetch(PDO::FETCH_ASSOC);
         if ($open) {
+            $bstmt = $pdo->prepare('SELECT blocked FROM transactions WHERE operationNumber=? FOR UPDATE');
+            $bstmt->execute(['T' . $open['id']]);
+            if ((int)$bstmt->fetchColumn() === 1) {
+                return ['ok'=>false,'msg'=>'Order blocked'];
+            }
             if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
             $deposit = $open['price'] * $order['quantity'];
             $profit  = ($open['price'] - $price) * $order['quantity'];
@@ -134,6 +139,11 @@ function executeTrade(PDO $pdo, array $order, float $price) {
 
     if ($open && $open['side'] === 'buy') {
         // Closing a long position
+        $bstmt = $pdo->prepare('SELECT blocked FROM transactions WHERE operationNumber=? FOR UPDATE');
+        $bstmt->execute(['T' . $open['id']]);
+        if ((int)$bstmt->fetchColumn() === 1) {
+            return ['ok'=>false,'msg'=>'Order blocked'];
+        }
         if ($open['quantity'] < $order['quantity']) return ['ok'=>false,'msg'=>'Position insuffisante'];
         $profit = ($price - $open['price']) * $order['quantity'];
         $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$total,$order['user_id']]);


### PR DESCRIPTION
## Summary
- Prevent closing short or long positions when their transaction is blocked
- Return HTTP 403 for market orders attempting to close blocked trades

## Testing
- `php -l utils/helpers.php`
- `php -l php/market_order.php`


------
https://chatgpt.com/codex/tasks/task_e_689747c72a7083328106b72a74cccc16