### PR TITLE
Respect order blocking when cancelling trades

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1786,18 +1786,22 @@ function initializeUI() {
                             quantity: openTrade.quantity
                         })
                     });
-                    showBootstrapAlert('cancelOrderAlert', 'Position clôturée.', 'success');
                 } else {
                     await apiFetch('php/cancel_order.php', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ user_id: userId, order_id: orderId })
                     });
-                    showBootstrapAlert('cancelOrderAlert', 'Ordre annulé.', 'success');
                 }
                 await fetchDashboardData();
+                $('#cancelOrderAlert').empty();
             } catch (e) {
-                showBootstrapAlert('cancelOrderAlert', e.message || 'Erreur lors de l\'annulation', 'danger');
+                const blocked = e.message === 'Order blocked';
+                showBootstrapAlert(
+                    'cancelOrderAlert',
+                    blocked ? 'Cet ordre ne peut pas être annulé.' : (e.message || 'Erreur lors de l\'annulation'),
+                    blocked ? 'warning' : 'danger'
+                );
             }
         } else {
             showBootstrapAlert('cancelOrderAlert', 'Cet ordre ne peut pas être annulé.', 'warning');

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -29,7 +29,7 @@ try{
         echo json_encode(['status'=>'error','message'=>'Order not cancellable']);
         exit;
     }
-    $bstmt=$pdo->prepare('SELECT blocked FROM transactions WHERE operationNumber=?');
+    $bstmt=$pdo->prepare('SELECT blocked FROM transactions WHERE operationNumber=? FOR UPDATE');
     $bstmt->execute(['T'.$orderId]);
     if((int)$bstmt->fetchColumn()===1){
         $pdo->rollBack();


### PR DESCRIPTION
## Summary
- Prevent cancelling blocked orders and remove success alerts for normal cancellations
- Refresh dashboard data after cancellation to update balances and statuses
- Lock transaction rows when verifying blocked status in cancel_order.php

## Testing
- `node --check js/updatePrices.js`
- `php -l php/cancel_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6897528ced08833282bf0fc2c875f9c3