### PR TITLE
Fix cancel order button by matching open trades

### DIFF
--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1773,7 +1773,7 @@ function initializeUI() {
         $btn.prop('disabled', true);
         const orderId = trade?.details?.order_id ?? trade?.order_id;
         if (trade && trade.statut === 'En cours' && orderId) {
-            const openTrade = (dashboardData.openTrades || []).find(t => t.id == orderId);
+            const openTrade = (dashboardData.openTrades || []).find(t => t.id == orderId || t.order_id == orderId);
             try {
                 if (openTrade) {
                     const side = openTrade.side === 'buy' ? 'sell' : 'buy';

--- a/php/getter.php
+++ b/php/getter.php
@@ -84,7 +84,7 @@ if ($verify) {
     }
 }
 
-$openTrades = fetchAll($pdo, 'SELECT id,pair,side,quantity,price FROM trades WHERE user_id = ? AND status="open"', [$userId]);
+$openTrades = fetchAll($pdo, 'SELECT id,order_id,pair,side,quantity,price FROM trades WHERE user_id = ? AND status="open"', [$userId]);
 foreach ($openTrades as &$t) {
     $current = getLivePrice($t['pair']);
     $t['current_price'] = $current;


### PR DESCRIPTION
## Summary
- include `order_id` when fetching open trades
- match cancel button to open trades by either trade `id` or `order_id`

## Testing
- `php -l php/getter.php`
- `node --check js/updatePrices.js`


------
https://chatgpt.com/codex/tasks/task_e_68975aa38afc8332a2e8f176a696ef95