### PR TITLE
Add automated limit order handling via cron job

### DIFF
--- a/cornjobs/auto_trading.php
+++ b/cornjobs/auto_trading.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__.'/../config/db_connection.php';
+require_once __DIR__.'/../utils/helpers.php';
+require_once __DIR__.'/../utils/poll.php';
+
+$pdo = db();
+
+$orders = $pdo->query('SELECT * FROM pending_orders')->fetchAll(PDO::FETCH_ASSOC);
+foreach ($orders as $o) {
+    $price = getLivePrice($o['pair']);
+    if ($price <= 0) { continue; }
+    $trigger = ($o['side'] === 'buy' && $price >= $o['price']) ||
+               ($o['side'] === 'sell' && $price <= $o['price']);
+    if (!$trigger) continue;
+
+    try {
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare('SELECT * FROM pending_orders WHERE id=? FOR UPDATE');
+        $stmt->execute([$o['id']]);
+        $order = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$order) { $pdo->rollBack(); continue; }
+        $price = getLivePrice($order['pair']);
+        $trigger = ($order['side'] === 'buy' && $price >= $order['price']) ||
+                   ($order['side'] === 'sell' && $price <= $order['price']);
+        if (!$trigger) { $pdo->rollBack(); continue; }
+        $tradeOrder = [
+            'user_id' => $order['user_id'],
+            'pair' => $order['pair'],
+            'side' => $order['side'],
+            'quantity' => $order['quantity']
+        ];
+        $result = executeTrade($pdo, $tradeOrder, $price);
+        if (!$result['ok']) { $pdo->rollBack(); continue; }
+        $pdo->prepare('DELETE FROM pending_orders WHERE id=?')->execute([$order['id']]);
+        addHistory($pdo, $order['user_id'], 'L'.$order['id'], $order['pair'], $order['side'], $order['quantity'], $price, 'complet', $result['profit']);
+        $pdo->commit();
+        pushEvent('balance_updated', ['newBalance' => $result['balance']], $order['user_id']);
+        if ($result['opened']) {
+            pushEvent('new_trade', [
+                'operation_number' => $result['operation'],
+                'pair' => $order['pair'],
+                'side' => $order['side'],
+                'quantity' => $order['quantity'],
+                'price' => $price,
+                'target_price' => $price,
+                'profit_loss' => $result['profit']
+            ], $order['user_id']);
+        } else {
+            pushEvent('order_cancelled', ['order_id' => ltrim($result['operation'], 'T')], $order['user_id']);
+        }
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) $pdo->rollBack();
+    }
+}

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -14,6 +14,7 @@ try {
     $qty=isset($input['quantity'])?(float)$input['quantity']:0.0;
     $amount=isset($input['amount'])?(float)$input['amount']:0.0;
     $side=strtolower($input['side']??'buy');
+    $type=strtolower($input['type']??'market');
     if(!$userId || !$pair || !in_array($side,['buy','sell'])){
         http_response_code(400);
         echo json_encode(['status'=>'error','message'=>'Missing parameters']);
@@ -27,6 +28,28 @@ try {
     require_once __DIR__.'/../config/db_connection.php';
     require_once __DIR__.'/../utils/helpers.php';
     $pdo=db();
+    if($type==='limit'){
+        $limitPrice=isset($input['limit_price'])?(float)$input['limit_price']:0.0;
+        if($limitPrice<=0){
+            http_response_code(400);
+            echo json_encode(['status'=>'error','message'=>'Invalid limit price']);
+            return;
+        }
+        if($qty<=0 && $amount>0){
+            $qty=$amount/$limitPrice;
+        }
+        if($qty<=0){
+            http_response_code(400);
+            echo json_encode(['status'=>'error','message'=>'Invalid amount']);
+            return;
+        }
+        $stmt=$pdo->prepare('INSERT INTO pending_orders (user_id,pair,side,quantity,price,type,created_at) VALUES (?,?,?,?,?,?,NOW())');
+        $stmt->execute([$userId,$pair,$side,$qty,$limitPrice,'limit']);
+        $orderId=$pdo->lastInsertId();
+        addHistory($pdo,$userId,'L'.$orderId,$pair,$side,$qty,$limitPrice,'En attente');
+        echo json_encode(['status'=>'ok','message'=>'Limit order placed']);
+        return;
+    }
     $livePrice=getLivePrice($pair);
     if($livePrice<=0){
         http_response_code(500);

--- a/run_cron_jobs.bat
+++ b/run_cron_jobs.bat
@@ -3,5 +3,6 @@ REM Run all cron jobs for the Coin Dashboard project in an infinite loop
 cd /d "%~dp0"
 
 :loop
+php -f cornjobs/auto_trading.php
 timeout /t 3 >nul
 goto loop

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -216,3 +216,15 @@ CREATE TABLE ftd (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
+CREATE TABLE pending_orders (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    pair VARCHAR(20),
+    side ENUM('buy','sell'),
+    quantity DECIMAL(20,10),
+    price DECIMAL(20,10),
+    type VARCHAR(20),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE
+) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- Support limit orders by storing them as pending and executing when price is reached
- Add auto_trading cron job to process pending limit orders
- Update cron runner to invoke new job and extend SQL schema

## Testing
- `php -l php/place_order.php`
- `php -l cornjobs/auto_trading.php`
- `php cornjobs/auto_trading.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897a282a5dc8332aa92571001e36c35