### PR TITLE
Integrate limit orders into trades table

### DIFF
--- a/cornjobs/auto_trading.php
+++ b/cornjobs/auto_trading.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../utils/poll.php';
 
 $pdo = db();
 
-$orders = $pdo->query('SELECT * FROM pending_orders')->fetchAll(PDO::FETCH_ASSOC);
+$orders = $pdo->query("SELECT * FROM trades WHERE type_order='limit' AND status='pending'")->fetchAll(PDO::FETCH_ASSOC);
 foreach ($orders as $o) {
     $price = getLivePrice($o['pair']);
     if ($price <= 0) { continue; }
@@ -15,7 +15,7 @@ foreach ($orders as $o) {
 
     try {
         $pdo->beginTransaction();
-        $stmt = $pdo->prepare('SELECT * FROM pending_orders WHERE id=? FOR UPDATE');
+        $stmt = $pdo->prepare("SELECT * FROM trades WHERE id=? FOR UPDATE");
         $stmt->execute([$o['id']]);
         $order = $stmt->fetch(PDO::FETCH_ASSOC);
         if (!$order) { $pdo->rollBack(); continue; }
@@ -31,7 +31,7 @@ foreach ($orders as $o) {
         ];
         $result = executeTrade($pdo, $tradeOrder, $price);
         if (!$result['ok']) { $pdo->rollBack(); continue; }
-        $pdo->prepare('DELETE FROM pending_orders WHERE id=?')->execute([$order['id']]);
+        $pdo->prepare('DELETE FROM trades WHERE id=?')->execute([$order['id']]);
         addHistory($pdo, $order['user_id'], 'L'.$order['id'], $order['pair'], $order['side'], $order['quantity'], $price, 'complet', $result['profit']);
         $pdo->commit();
         pushEvent('balance_updated', ['newBalance' => $result['balance']], $order['user_id']);

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -43,8 +43,9 @@ try {
             echo json_encode(['status'=>'error','message'=>'Invalid amount']);
             return;
         }
-        $stmt=$pdo->prepare('INSERT INTO pending_orders (user_id,pair,side,quantity,price,type,created_at) VALUES (?,?,?,?,?,?,NOW())');
-        $stmt->execute([$userId,$pair,$side,$qty,$limitPrice,'limit']);
+        $total=$limitPrice*$qty;
+        $stmt=$pdo->prepare('INSERT INTO trades (user_id,pair,side,quantity,price,total_value,fee,profit_loss,status,type_order) VALUES (?,?,?,?,?,?,0,0,"pending","limit")');
+        $stmt->execute([$userId,$pair,$side,$qty,$limitPrice,$total]);
         $orderId=$pdo->lastInsertId();
         addHistory($pdo,$userId,'L'.$orderId,$pair,$side,$qty,$limitPrice,'En attente');
         echo json_encode(['status'=>'ok','message'=>'Limit order placed']);

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -184,7 +184,8 @@ CREATE TABLE trades (
     total_value DECIMAL(20,10),
     fee DECIMAL(20,10) DEFAULT 0,
     profit_loss DECIMAL(20,10) DEFAULT 0,
-    status ENUM('open','closed') DEFAULT 'open',
+    status ENUM('open','closed','pending') DEFAULT 'open',
+    type_order ENUM('market','limit') DEFAULT 'market',
     close_price DECIMAL(20,10),
     closed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -217,14 +218,3 @@ CREATE TABLE ftd (
     FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
-CREATE TABLE pending_orders (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    user_id BIGINT NOT NULL,
-    pair VARCHAR(20),
-    side ENUM('buy','sell'),
-    quantity DECIMAL(20,10),
-    price DECIMAL(20,10),
-    type VARCHAR(20),
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES personal_data(user_id) ON DELETE CASCADE
-) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- remove pending_orders table and extend trades with `type_order`
- process limit orders from trades in auto_trading
- insert limit orders into trades when placing orders

## Testing
- `php -l php/place_order.php`
- `php -l cornjobs/auto_trading.php`


------
https://chatgpt.com/codex/tasks/task_e_6897a599bc908332b9902b7428524cb6