### PR TITLE
Add stop order handling with automatic trade closure

### DIFF
--- a/cornjobs/auto_trading.php
+++ b/cornjobs/auto_trading.php
@@ -52,3 +52,36 @@ foreach ($orders as $o) {
         if ($pdo->inTransaction()) $pdo->rollBack();
     }
 }
+
+$stopOrders = $pdo->query("SELECT * FROM trades WHERE status='open' AND stop_price IS NOT NULL ORDER BY id ASC")->fetchAll(PDO::FETCH_ASSOC);
+foreach ($stopOrders as $t) {
+    $price = getLivePrice($t['pair']);
+    if ($price <= 0) { continue; }
+    $trigger = ($t['side'] === 'buy' && $price <= $t['stop_price']) ||
+               ($t['side'] === 'sell' && $price >= $t['stop_price']);
+    if (!$trigger) continue;
+    try {
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare("SELECT * FROM trades WHERE id=? FOR UPDATE");
+        $stmt->execute([$t['id']]);
+        $trade = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$trade) { $pdo->rollBack(); continue; }
+        $price = getLivePrice($trade['pair']);
+        $trigger = ($trade['side'] === 'buy' && $price <= $trade['stop_price']) ||
+                   ($trade['side'] === 'sell' && $price >= $trade['stop_price']);
+        if (!$trigger) { $pdo->rollBack(); continue; }
+        $closeOrder = [
+            'user_id' => $trade['user_id'],
+            'pair' => $trade['pair'],
+            'side' => $trade['side'] === 'buy' ? 'sell' : 'buy',
+            'quantity' => $trade['quantity']
+        ];
+        $result = executeTrade($pdo, $closeOrder, $price);
+        if (!$result['ok']) { $pdo->rollBack(); continue; }
+        $pdo->commit();
+        pushEvent('balance_updated', ['newBalance' => $result['balance']], $trade['user_id']);
+        pushEvent('order_cancelled', ['order_id' => ltrim($result['operation'], 'T')], $trade['user_id']);
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) $pdo->rollBack();
+    }
+}

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -51,6 +51,15 @@ try {
         echo json_encode(['status'=>'ok','message'=>'Limit order placed']);
         return;
     }
+    $stopPrice=null;
+    if($type==='stop'){
+        $stopPrice=isset($input['stop_price'])?(float)$input['stop_price']:0.0;
+        if($stopPrice<=0){
+            http_response_code(400);
+            echo json_encode(['status'=>'error','message'=>'Invalid stop price']);
+            return;
+        }
+    }
     $livePrice=getLivePrice($pair);
     if($livePrice<=0){
         http_response_code(500);
@@ -73,6 +82,11 @@ try {
         http_response_code(400);
         echo json_encode(['status'=>'error','message'=>$result['msg']]);
         return;
+    }
+    if($type==='stop' && $result['opened']){
+        $tradeId=(int)ltrim($result['operation'],'T');
+        $stmt=$pdo->prepare('UPDATE trades SET stop_price=? WHERE id=?');
+        $stmt->execute([$stopPrice,$tradeId]);
     }
     $pdo->commit();
     require_once __DIR__.'/../utils/poll.php';

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -186,6 +186,7 @@ CREATE TABLE trades (
     profit_loss DECIMAL(20,10) DEFAULT 0,
     status ENUM('open','closed','pending') DEFAULT 'open',
     type_order ENUM('market','limit') DEFAULT 'market',
+    stop_price DECIMAL(20,10),
     close_price DECIMAL(20,10),
     closed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- allow stop orders to specify a trigger price when placing a market trade
- store stop prices on trades for later evaluation
- background job closes open trades once market price hits their stop level

## Testing
- `php -l php/place_order.php`
- `php -l cornjobs/auto_trading.php`


------
https://chatgpt.com/codex/tasks/task_e_6897ccb0e038833298fbe6b4f18699f5