### PR TITLE
Broadcast fixed trade profits

### DIFF
--- a/js/longPollClient.js
+++ b/js/longPollClient.js
@@ -43,6 +43,9 @@ function handleEvents(response) {
       case 'order_cancelled':
         if (window.handleOrderCancelled) window.handleOrderCancelled(ev.data);
         break;
+      case 'trade_profit_fixed':
+        if (window.handleTradeProfitFixed) window.handleTradeProfitFixed(ev.data);
+        break;
       default:
         break;
     }

--- a/js/updatePrices.js
+++ b/js/updatePrices.js
@@ -1504,6 +1504,29 @@ function initializeUI() {
         }
     };
 
+    window.handleTradeProfitFixed = function(data) {
+        const op = String(data.operation_number || '').trim();
+        const profit = parseFloat(data.profit);
+        const price = parseFloat(data.price);
+        const cls = data.profitClass || (profit >= 0 ? 'text-success' : 'text-danger');
+        const idx = (dashboardData.tradingHistory || []).findIndex(t => t.operationNumber === op);
+        if (idx !== -1) {
+            const trade = dashboardData.tradingHistory[idx];
+            trade.profitPerte = profit;
+            trade.prix = price;
+            trade.profitClass = cls;
+        }
+        const $row = $(`#tradingHistory tr[data-op="${escapeHtml(op)}"]`);
+        if ($row.length) {
+            $row.find('td').eq(5).text(formatDollar(price));
+            $row.find('[data-profit]')
+                .text(formatDollar(profit))
+                .removeClass('text-success text-danger')
+                .addClass(cls)
+                .attr('data-profit-fixed', '1');
+        }
+    };
+
     function finalizeOrder(order, exitPrice) {
         const priceValue = parseFloat(order.prix);
         const qty = parseFloat(order.montant);

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -7,6 +7,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
 try {
     require_once __DIR__.'/../config/db_connection.php';
     require_once __DIR__.'/../utils/permissions.php';
+    require_once __DIR__.'/../utils/poll.php';
     $pdo = db();
 
     $updateVerify = function(int $uid) use ($pdo){
@@ -336,6 +337,12 @@ try {
             }
             $pdo->prepare('UPDATE personal_data SET balance = balance + ? WHERE user_id = ?')->execute([$diff, $userId]);
             $pdo->commit();
+            pushEvent('trade_profit_fixed', [
+                'operation_number' => $op,
+                'profit' => $profit,
+                'price' => $newPrice,
+                'profitClass' => $profitClass
+            ], $userId);
             echo json_encode(['status' => 'ok', 'prix' => $newPrice, 'profitClass' => $profitClass]);
         } catch (Exception $e) {
             $pdo->rollBack();


### PR DESCRIPTION
## Summary
- push trade_profit_fixed events from admin profit edits
- update polling client and dashboard to lock profits after admin changes

## Testing
- `php -l php/admin_setter.php`
- `node --check js/updatePrices.js`
- `node --check js/longPollClient.js`


------
https://chatgpt.com/codex/tasks/task_e_6897e4d488308332ac275294e98f8cd1