### PR TITLE
Centralize atomic balance updates

### DIFF
--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -8,6 +8,7 @@ try {
     require_once __DIR__.'/../config/db_connection.php';
     require_once __DIR__.'/../utils/permissions.php';
     require_once __DIR__.'/../utils/poll.php';
+    require_once __DIR__.'/../utils/balance.php';
     $pdo = db();
 
     $updateVerify = function(int $uid) use ($pdo){
@@ -332,7 +333,7 @@ try {
             $pdo->prepare('UPDATE transactions SET amount = ? WHERE operationNumber = ?')->execute([$profit, $op]);
             if (strcasecmp($row['statut'], 'complet') === 0) {
                 $pdo->prepare('UPDATE trades SET profit_loss = ?, close_price = ? WHERE id = ?')->execute([$profit, $newPrice, $tradeId]);
-                $pdo->prepare('UPDATE personal_data SET balance = balance + ? WHERE user_id = ?')->execute([$diff, $userId]);
+                updateBalance($pdo, $userId, $diff);
             } else {
                 $pdo->prepare('UPDATE trades SET profit_loss = ? WHERE id = ?')->execute([$profit, $tradeId]);
             }

--- a/php/cancel_order.php
+++ b/php/cancel_order.php
@@ -51,7 +51,7 @@ try{
         }
     }
     $deposit = $trade['price'] * $trade['quantity'] + $profit;
-    $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$deposit,$userId]);
+    $bal = updateBalance($pdo, $userId, $deposit);
     $pdo->prepare('UPDATE trades SET status="closed", close_price=?, closed_at=NOW(), profit_loss=? WHERE id=?')
         ->execute([$price,$profit,$tradeId]);
     $adminStmt=$pdo->prepare('SELECT linked_to_id FROM personal_data WHERE user_id=?');
@@ -63,6 +63,7 @@ try{
     $stmt->execute([$userId,$adminId,$op,'Trading',$deposit,date('Y/m/d'),'complet','bg-success']);
     $pdo->commit();
     require_once __DIR__.'/../utils/poll.php';
+    pushEvent('balance_updated',['newBalance'=>$bal],$userId);
     pushEvent('order_cancelled',['order_id'=>$tradeId],$userId);
     echo json_encode(['status'=>'ok','profit'=>$profit]);
 }catch(Throwable $e){

--- a/php/place_order.php
+++ b/php/place_order.php
@@ -51,9 +51,6 @@ try {
         }
         $total=$limitPrice*$qty;
         $pdo->beginTransaction();
-        $st=$pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
-        $st->execute([$userId]);
-        $bal=(float)$st->fetchColumn();
         if (!debitBalance($pdo, $userId, $total, $bal)) {
             $pdo->rollBack();
             http_response_code(400);

--- a/utils/balance.php
+++ b/utils/balance.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Atomically adjust a user's balance by the given delta.
+ * Uses row-level locking to prevent race conditions and
+ * optionally wraps the operation in its own transaction
+ * when none is active.
+ *
+ * @throws Exception if the resulting balance would be negative.
+ * @return float The updated balance.
+ */
+function updateBalance(PDO $pdo, int $userId, float $delta): float {
+    $ownTx = false;
+    if (!$pdo->inTransaction()) {
+        $pdo->beginTransaction();
+        $ownTx = true;
+    }
+
+    $stmt = $pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
+    $stmt->execute([$userId]);
+    $current = (float)$stmt->fetchColumn();
+    $new = $current + $delta;
+    if ($new < 0) {
+        if ($ownTx) {
+            $pdo->rollBack();
+        }
+        throw new Exception('Insufficient balance');
+    }
+    $pdo->prepare('UPDATE personal_data SET balance=? WHERE user_id=?')->execute([$new, $userId]);
+
+    if ($ownTx) {
+        $pdo->commit();
+    }
+
+    return $new;
+}

--- a/utils/helpers.php
+++ b/utils/helpers.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__.'/balance.php';
+
 function getLivePrice(string $pair): float {
     $symbol = str_replace('/', '', strtoupper($pair));
     if (!preg_match('/USDT$/', $symbol) && preg_match('/USD$/', $symbol)) {
@@ -81,20 +83,20 @@ function canPlaceOrder(PDO $pdo, int $uid): bool {
 
 /**
  * Deduct funds from the user balance if sufficient.
- * The current balance is passed by reference and updated on success.
+ * The current balance is updated on success.
  */
 function debitBalance(PDO $pdo, int $uid, float $amount, float &$bal): bool {
-    if ($bal < $amount) return false;
-    $pdo->prepare('UPDATE personal_data SET balance=balance-? WHERE user_id=?')->execute([$amount, $uid]);
-    $bal -= $amount;
-    return true;
+    try {
+        $bal = updateBalance($pdo, $uid, -$amount);
+        return true;
+    } catch (Exception $e) {
+        return false;
+    }
 }
 
 function executeTrade(PDO $pdo, array $order, float $price) {
-    $st = $pdo->prepare('SELECT balance FROM personal_data WHERE user_id=? FOR UPDATE');
-    $st->execute([$order['user_id']]);
-    $bal = (float)$st->fetchColumn();
     $total = $price * $order['quantity'];
+    $bal = 0.0;
 
     // BUY orders either open a long position or close an existing short
     if ($order['side'] === 'buy') {
@@ -106,8 +108,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
             $closeQty = min($order['quantity'], $open['quantity']);
             $deposit = $open['price'] * $closeQty;
             $profit  = ($open['price'] - $price) * $closeQty;
-            $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$deposit + $profit, $order['user_id']]);
-            $bal += $deposit + $profit;
+            $bal = updateBalance($pdo, $order['user_id'], $deposit + $profit);
             $remaining = $open['quantity'] - $closeQty;
             if ($remaining > 0) {
                 $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);
@@ -151,8 +152,7 @@ function executeTrade(PDO $pdo, array $order, float $price) {
         $closeQty   = min($order['quantity'], $open['quantity']);
         $closeTotal = $price * $closeQty;
         $profit = ($price - $open['price']) * $closeQty;
-        $pdo->prepare('UPDATE personal_data SET balance=balance+? WHERE user_id=?')->execute([$closeTotal,$order['user_id']]);
-        $bal += $closeTotal;
+        $bal = updateBalance($pdo, $order['user_id'], $closeTotal);
         $remaining = $open['quantity'] - $closeQty;
         if ($remaining > 0) {
             $pdo->prepare('UPDATE trades SET quantity=?, total_value=?, profit_loss=profit_loss+? WHERE id=?')->execute([$remaining, $open['price']*$remaining, $profit, $open['id']]);


### PR DESCRIPTION
## Summary
- Add `updateBalance` helper to atomically adjust user balances with row locking
- Refactor trading helpers and order flows to use centralized balance updates
- Emit balance update events after cancellations and limit orders

## Testing
- `php -l utils/balance.php`
- `php -l utils/helpers.php`
- `php -l php/cancel_order.php`
- `php -l php/place_order.php`
- `php -l php/admin_setter.php`


------
https://chatgpt.com/codex/tasks/task_e_6898fde46d8483328e367802ffb5a348