### PR TITLE
Initialize balance before debit to avoid null float argument

### DIFF
--- a/php/place_order.php
+++ b/php/place_order.php
@@ -45,6 +45,7 @@ try {
             return;
         }
         $total=$limitPrice*$qty;
+        $bal=0.0;
         $pdo->beginTransaction();
         if (!debitBalance($pdo, $userId, $total, $bal)) {
             $pdo->rollBack();


### PR DESCRIPTION
## Summary
- Ensure `$bal` is initialized to `0.0` before calling `debitBalance` for limit orders

## Testing
- `php -l php/place_order.php`


------
https://chatgpt.com/codex/tasks/task_e_6899e2253f8c83328c142b6b09f8146c