### PR TITLE
Show FTD notes and phone in admin user details

### DIFF
--- a/ONLINE/create_table.sql
+++ b/ONLINE/create_table.sql
@@ -60,7 +60,6 @@ CREATE TABLE personal_data (
     userAccountNumber TEXT,
     userIban TEXT,
     userSwiftCode TEXT,
-    note TEXT,
     linked_to_id BIGINT,
     profile_pic MEDIUMTEXT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/ONLINE/insert.sql
+++ b/ONLINE/insert.sql
@@ -8,7 +8,7 @@ INSERT INTO personal_data (
     emailNotifications, smsNotifications, loginAlerts, transactionAlerts,
     twoFactorAuth, emailaddress, address, phone, dob, nationality, created_at,
     userBankName, userAccountName, userAccountNumber, userIban, userSwiftCode,
-    note, linked_to_id, profile_pic
+    linked_to_id, profile_pic
 ) VALUES (
     1, 3500, 3000, 1200, '10',
     'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2',
@@ -17,7 +17,7 @@ INSERT INTO personal_data (
     '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000',
     '2025-06-11', 'ca', '2025-01-01',
     'Bank of Earth', 'Ahmed Kouraychi',
-    'ACC123456', 'IBAN123456', 'SWIFT123', '', 1, NULL
+    'ACC123456', 'IBAN123456', 'SWIFT123', 1, NULL
 );
 
 INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -530,10 +530,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="mb-3">
-                            <label for="userNote" class="form-label">Note</label>
-                            <textarea class="form-control" id="userNote" rows="3"></textarea>
-                        </div>
                         <h6 class="mt-3">Coordonnées bancaires pour les dépôts</h6>
                         <div class="row">
                             <div class="col-md-6 mb-3">
@@ -669,8 +665,9 @@
                 <div class="modal-body">
                     <p><strong>Nom:</strong> <span id="viewFullName"></span></p>
                     <p><strong>Email:</strong> <span id="viewEmail"></span></p>
+                    <p><strong>Téléphone:</strong> <span id="viewPhone"></span></p>
                     <p><strong>Date d'inscription:</strong> <span id="viewCreated"></span></p>
-                    <p><strong>Note:</strong> <span id="viewNote"></span></p>
+                    <p><strong>Note FTD:</strong> <span id="viewFtdNote"></span></p>
                     <div class="progress mb-3">
                         <div class="progress-bar" id="viewKycBar" role="progressbar" style="width:0%">0%</div>
                     </div>
@@ -1534,7 +1531,6 @@
             const firstName = document.getElementById('firstName').value.trim();
             const lastName = document.getElementById('lastName').value.trim();
             const email = document.getElementById('email').value.trim();
-            const note = document.getElementById('userNote').value.trim();
             const bankInfo = {
                 widhrawBankName: document.getElementById('createBwBankName').value.trim(),
                 widhrawAccountName: document.getElementById('createBwAccountName').value.trim(),
@@ -1549,7 +1545,6 @@
                     user_id: Date.now(),
                     fullName: firstName + ' ' + lastName,
                     emailaddress: email,
-                    note: note,
                     passwordStrength: strengthLabel(score),
                     passwordStrengthBar: score + '%',
                     password: md5(password),
@@ -1647,8 +1642,10 @@
                 const pd = data.personalData || {};
                 document.getElementById('viewFullName').textContent = pd.fullName || '';
                 document.getElementById('viewEmail').textContent = pd.emailaddress || '';
+                document.getElementById('viewPhone').textContent = pd.phone || '';
                 document.getElementById('viewCreated').textContent = pd.created_at || '';
-                document.getElementById('viewNote').textContent = pd.note || '';
+                const ftd = data.ftd || {};
+                document.getElementById('viewFtdNote').textContent = ftd.call_notes || '';
                 const steps = Object.values(data.defaultKYCStatus || {});
                 const completed = steps.filter(s => String(s.status) === '1').length;
                 const pct = Math.round((completed / steps.length) * 100);

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -87,7 +87,7 @@ switch ($period) {
         break;
 }
 
-$userColsNoLink = 'user_id,balance,totalDepots,totalRetraits,nbTransactions,fullName,compteverifie,compteverifie01,niveauavance,passwordHash,passwordStrength,passwordStrengthBar,emailNotifications,smsNotifications,loginAlerts,transactionAlerts,twoFactorAuth,emailaddress,address,phone,dob,nationality,created_at,userBankName,userAccountName,userAccountNumber,userIban,userSwiftCode,note,profile_pic';
+$userColsNoLink = 'user_id,balance,totalDepots,totalRetraits,nbTransactions,fullName,compteverifie,compteverifie01,niveauavance,passwordHash,passwordStrength,passwordStrengthBar,emailNotifications,smsNotifications,loginAlerts,transactionAlerts,twoFactorAuth,emailaddress,address,phone,dob,nationality,created_at,userBankName,userAccountName,userAccountNumber,userIban,userSwiftCode,profile_pic';
 $userSql = 'SELECT ' . ((int)$admin['is_admin'] === 2 ? '*' : $userColsNoLink) . ' FROM personal_data';
 $userParams = [];
 if ((int)$admin['is_admin'] !== 2) {

--- a/php/admin_setter.php
+++ b/php/admin_setter.php
@@ -95,7 +95,7 @@ try {
         'loginAlerts','transactionAlerts','twoFactorAuth','emailaddress','address',
         'phone','dob','nationality','created_at',
         'userBankName','userAccountName','userAccountNumber','userIban','userSwiftCode',
-        'note','linked_to_id'
+        'linked_to_id'
     ];
 
     $action = $data['action'] ?? '';

--- a/php/getter.php
+++ b/php/getter.php
@@ -54,6 +54,8 @@ if ($adminLevel !== 2) {
 }
 $bankWithdraw = fetchAll($pdo, 'SELECT * FROM bank_withdrawl_info WHERE user_id = ? LIMIT 1', [$userId]);
 $bankWithdraw = $bankWithdraw ? $bankWithdraw[0] : [];
+$ftdData = fetchAll($pdo, 'SELECT call_notes FROM ftd WHERE user_id = ? ORDER BY id DESC LIMIT 1', [$userId]);
+$ftdData = $ftdData ? $ftdData[0] : new stdClass();
 $notifications = fetchAll($pdo, 'SELECT DISTINCT type,title,message,time,alertClass FROM notifications WHERE user_id = ? ORDER BY id DESC LIMIT 100', [$userId]);
 foreach ($notifications as &$n) {
     $n['time'] = formatTimeAgoFromDate($n['time']);
@@ -129,6 +131,7 @@ $data = [
     }, fetchAll($pdo, 'SELECT operationNumber,temps,paireDevises,type,statutTypeClass,montant,prix,statut,statutClass,profitPerte,profitClass,details FROM tradingHistory WHERE user_id = ? ORDER BY id DESC', [$userId])),
     'loginHistory' => fetchAll($pdo, 'SELECT date,ip,device FROM loginHistory WHERE user_id = ? ORDER BY STR_TO_DATE(date, "%Y/%m/%d") DESC, id DESC LIMIT 100', [$userId]),
     'bankWithdrawInfo' => $bankWithdraw,
+    'ftd' => $ftdData,
     'cryptoDepositAddresses' => fetchAll($pdo, 'SELECT id,crypto_name,wallet_info FROM deposit_crypto_address WHERE user_id = ?', [$userId]),
     'kycDocs' => $kycRows,
     // placeholders for front-end

--- a/sql/createtable.sql
+++ b/sql/createtable.sql
@@ -37,7 +37,6 @@ CREATE TABLE personal_data (
     userAccountNumber TEXT,
     userIban TEXT,
     userSwiftCode TEXT,
-    note TEXT,
     linked_to_id INTEGER,
     profile_pic MEDIUMTEXT
 ) ENGINE=InnoDB;

--- a/sql/insertdata.sql
+++ b/sql/insertdata.sql
@@ -8,7 +8,7 @@ INSERT INTO personal_data (
     emailNotifications, smsNotifications, loginAlerts, transactionAlerts,
     twoFactorAuth, emailaddress, address, phone, dob, nationality, created_at,
     userBankName, userAccountName, userAccountNumber, userIban, userSwiftCode,
-    note, linked_to_id, profile_pic
+    linked_to_id, profile_pic
 ) VALUES (
     1, 3500, 3000, 1200, '10',
     'Ahmed Kouraychi', 'Vérifié', '1', 'Niveau 2',
@@ -17,7 +17,7 @@ INSERT INTO personal_data (
     '41kira41@gmail.com', 'Sousse, Tunisie', '+21690000000',
     '2025-06-11', 'ca', '2025-01-01',
     'Bank of Earth', 'Ahmed Kouraychi',
-    'ACC123456', 'IBAN123456', 'SWIFT123', '', 1, NULL
+    'ACC123456', 'IBAN123456', 'SWIFT123', 1, NULL
 );
 
 INSERT INTO deposit_crypto_address (user_id, crypto_name, wallet_info) VALUES


### PR DESCRIPTION
## Summary
- Remove legacy personal note field from user creation and admin/user APIs
- Display phone number and FTD call notes in the user details modal
- Drop `note` column from SQL schema and sample data

## Testing
- `php -l php/admin_getter.php`
- `php -l php/admin_setter.php`
- `php -l php/getter.php`


------
https://chatgpt.com/codex/tasks/task_e_689f45a2e1e883328e94adcb654a7d59