### PR TITLE
feat: include pending trades in admin transactions

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -105,7 +105,23 @@ AFTER INSERT ON trades
 FOR EACH ROW
 BEGIN
   DECLARE op VARCHAR(50);
+  DECLARE txStatus TEXT;
+  DECLARE txClass  TEXT;
+
   SET op = CONCAT('T', NEW.id);
+
+  SET txStatus = CASE
+      WHEN NEW.status IN ('open', 'pending') THEN 'En cours'
+      WHEN NEW.status = 'closed' THEN 'complet'
+      ELSE NEW.status
+  END;
+
+  SET txClass = CASE
+      WHEN NEW.status IN ('open', 'pending') THEN 'bg-warning'
+      WHEN NEW.status = 'closed' THEN 'bg-success'
+      ELSE 'bg-secondary'
+  END;
+
   INSERT INTO transactions
     (user_id, admin_id, operationNumber, type, amount, date, status, statusClass)
     VALUES (
@@ -115,8 +131,8 @@ BEGIN
       'Trading',
       NEW.total_value,
       DATE_FORMAT(NEW.created_at, '%Y/%m/%d'),
-      'complet',
-      'bg-success'
+      txStatus,
+      txClass
     )
     ON DUPLICATE KEY UPDATE
       amount = VALUES(amount),


### PR DESCRIPTION
## Summary
- record newly created trades in transactions table with the correct status so admins can view pending orders

## Testing
- `php -l php/admin_transactions_getter.php`


------
https://chatgpt.com/codex/tasks/task_e_689f505273a883329338ab2b766a8622